### PR TITLE
fix: ProfileController: add missing props

### DIFF
--- a/src/profile/controllers/profile.controller.spec.ts
+++ b/src/profile/controllers/profile.controller.spec.ts
@@ -2,9 +2,24 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ProfileController } from './profile.controller';
 import { Player } from '@/players/models/player';
 import { PlayersService } from '@/players/services/players.service';
+import { GamesService } from '@/games/services/games.service';
+import { PlayerBansService } from '@/players/services/player-bans.service';
+import { MapVoteService } from '@/queue/services/map-vote.service';
 
 class PlayersServiceStub {
   acceptTerms(playerId: string) { return null; }
+}
+
+class GamesServiceStub {
+  getPlayerActiveGame(playerId: string) { return new Promise(resolve => resolve(null)); }
+}
+
+class PlayerBansServiceStub {
+  getPlayerActiveBans(playerId: string) { return new Promise(resolve => resolve([])); }
+}
+
+class MapVoteServiceStub {
+  playerVote(playerId: string) { return 'cp_badlands'; }
 }
 
 describe('Profile Controller', () => {
@@ -15,6 +30,9 @@ describe('Profile Controller', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         { provide: PlayersService, useClass: PlayersServiceStub },
+        { provide: GamesService, useClass: GamesServiceStub },
+        { provide: PlayerBansService, useClass: PlayerBansServiceStub },
+        { provide: MapVoteService, useClass: MapVoteServiceStub },
       ],
       controllers: [ProfileController],
     }).compile();
@@ -28,9 +46,10 @@ describe('Profile Controller', () => {
   });
 
   describe('#getProfile()', () => {
-    it('should return the logged-in user\'s profile', () => {
-      const user: Player = { id: 'FAKE_ID', name: 'FAKE_USER_NAME', steamId: 'FAKE_STEAM_ID', hasAcceptedRules: false };
-      expect(controller.getProfile(user)).toEqual(user);
+    it('should return the logged-in user\'s profile', async () => {
+      const profile = { id: 'FAKE_ID', name: 'FAKE_USER_NAME', steamId: 'FAKE_STEAM_ID', hasAcceptedRules: false, activeGameId: null, bans: [],
+        mapVote: 'cp_badlands' };
+      expect(await controller.getProfile(profile)).toEqual(profile as any);
     });
   });
 

--- a/src/profile/controllers/profile.controller.ts
+++ b/src/profile/controllers/profile.controller.ts
@@ -3,18 +3,27 @@ import { Auth } from '@/auth/decorators/auth.decorator';
 import { User } from '@/auth/decorators/user.decorator';
 import { Player } from '@/players/models/player';
 import { PlayersService } from '@/players/services/players.service';
+import { GamesService } from '@/games/services/games.service';
+import { PlayerBansService } from '@/players/services/player-bans.service';
+import { MapVoteService } from '@/queue/services/map-vote.service';
 
 @Controller('profile')
 export class ProfileController {
 
   constructor(
     private playersService: PlayersService,
+    private gamesService: GamesService,
+    private playerBansService: PlayerBansService,
+    private mapVoteService: MapVoteService,
   ) { }
 
   @Auth()
   @Get()
-  getProfile(@User() user: Player) {
-    return user;
+  async getProfile(@User() user: Player) {
+    const activeGameId = (await this.gamesService.getPlayerActiveGame(user.id))?.id ?? null;
+    const bans = await this.playerBansService.getPlayerActiveBans(user.id);
+    const mapVote = this.mapVoteService.playerVote(user.id);
+    return { ...user, activeGameId, bans, mapVote };
   }
 
   @Auth()

--- a/src/profile/profile.module.ts
+++ b/src/profile/profile.module.ts
@@ -2,11 +2,15 @@ import { Module } from '@nestjs/common';
 import { ProfileController } from './controllers/profile.controller';
 import { AuthModule } from '@/auth/auth.module';
 import { PlayersModule } from '@/players/players.module';
+import { GamesModule } from '@/games/games.module';
+import { QueueModule } from '@/queue/queue.module';
 
 @Module({
   imports: [
     AuthModule,
+    GamesModule,
     PlayersModule,
+    QueueModule,
   ],
   controllers: [
     ProfileController,

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -25,7 +25,10 @@ import { QueueController } from './controllers/queue.controller';
   exports: [
     QueueService,
     QueueConfigService,
+    MapVoteService,
   ],
-  controllers: [QueueController],
+  controllers: [
+    QueueController,
+  ],
 })
 export class QueueModule { }


### PR DESCRIPTION
Adds missing props: `activeGameId`, `bans` and `mapVote`.