### PR TITLE
fix: profile creation

### DIFF
--- a/src/players/services/etf2l-profile.service.spec.ts
+++ b/src/players/services/etf2l-profile.service.spec.ts
@@ -44,7 +44,7 @@ describe('Etf2lProfileService', () => {
     it('should query the ETF2L API', async () => {
       const spy = spyOn(httpService, 'get').and.returnValue(of(response));
       const res = await service.fetchPlayerInfo('FAKE_STEAM_ID');
-      expect(spy).toHaveBeenCalledWith('http://api.etf2l.org/player/FAKE_STEAM_ID');
+      expect(spy).toHaveBeenCalledWith('http://api.etf2l.org/player/FAKE_STEAM_ID.json');
       expect(res).toEqual(etf2lProfile);
     });
 

--- a/src/players/services/etf2l-profile.service.ts
+++ b/src/players/services/etf2l-profile.service.ts
@@ -21,7 +21,7 @@ export class Etf2lProfileService {
   ) { }
 
   async fetchPlayerInfo(steamId: string): Promise<Etf2lProfile> {
-    return this.httpService.get<Etf2lPlayerResponse>(`${this.etf2lEndpoint}/player/${steamId}`).pipe(
+    return this.httpService.get<Etf2lPlayerResponse>(`${this.etf2lEndpoint}/player/${steamId}.json`).pipe(
       catchError(error => {
         const response = error.response;
         switch (response.status) {


### PR DESCRIPTION
Fixes an exception being throw upon profile creation due to ETF2L API returning HTML data instead of JSON-formatted one.