### PR TITLE
fix: player substitution logic update

### DIFF
--- a/src/games/models/game-player.ts
+++ b/src/games/models/game-player.ts
@@ -9,11 +9,11 @@ export class GamePlayer {
   teamId!: string;
 
   @prop({ required: true })
-  gameClass: string;
+  gameClass!: string;
 
   @prop({ default: 'active' })
-  status: 'active' | 'waiting for substitute' | 'replaced';
+  status?: 'active' | 'waiting for substitute' | 'replaced';
 
   @prop({ default: 'offline' })
-  connectionStatus: PlayerConnectionStatus;
+  connectionStatus?: PlayerConnectionStatus;
 }

--- a/src/games/services/games.service.ts
+++ b/src/games/services/games.service.ts
@@ -94,7 +94,15 @@ export class GamesService {
   }
 
   async getPlayerActiveGame(playerId: string): Promise<DocumentType<Game>> {
-    return await this.gameModel.findOne({ state: /launching|started/, players: playerId });
+    return await this.gameModel.findOne({
+      state: /launching|started/,
+      slots: {
+        $elemMatch: {
+          status: /active|waiting for substitute/,
+          playerId,
+        },
+      },
+    });
   }
 
   async create(queueSlots: QueueSlot[], map: string): Promise<DocumentType<Game>> {

--- a/src/games/services/games.service.ts
+++ b/src/games/services/games.service.ts
@@ -167,7 +167,7 @@ export class GamesService {
   async getGamesWithSubstitutionRequests(): Promise<Array<DocumentType<Game>>> {
     return this.gameModel
       .find({
-        'state': /launching|started/,
+        'state': { $in: ['launching', 'started'] },
         'slots.status': 'waiting for substitute',
       });
   }

--- a/src/games/services/player-substitution.service.spec.ts
+++ b/src/games/services/player-substitution.service.spec.ts
@@ -59,8 +59,12 @@ class PlayersServiceStub {
 
   getById(id: string) {
     return new Promise(resolve => {
-      const player = { ...this.players.get(id) };
-      resolve(player);
+      const player = this.players.get(id);
+      if (player) {
+        resolve({ ...player });
+      } else {
+        resolve(null);
+      }
     });
   }
 }
@@ -300,6 +304,10 @@ describe('PlayerSubstitutionService', () => {
       const spy = spyOn(queueGateway, 'updateSubstituteRequests');
       await service.replacePlayer('FAKE_GAME_ID', 'FAKE_PLAYER_1', 'FAKE_PLAYER_3');
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('should reject if the replacement player does not exist', async () => {
+      await expectAsync(service.replacePlayer('FAKE_GAME_ID', 'FAKE_PLAYER_1', 'some nonexistent player id')).toBeRejectedWithError('no such player');
     });
   });
 

--- a/src/games/services/player-substitution.service.spec.ts
+++ b/src/games/services/player-substitution.service.spec.ts
@@ -180,6 +180,12 @@ describe('PlayerSubstitutionService', () => {
       await service.substitutePlayer('FAKE_GAME_ID', 'FAKE_PLAYER_1');
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should do nothing if the player is already marked', async () => {
+      const game1 = await service.substitutePlayer('FAKE_GAME_ID', 'FAKE_PLAYER_1');
+      const game2 = await service.substitutePlayer('FAKE_GAME_ID', 'FAKE_PLAYER_1');
+      expect(game1).toEqual(game2);
+    });
   });
 
   describe('#cancelSubstitutionRequest()', () => {
@@ -224,6 +230,12 @@ describe('PlayerSubstitutionService', () => {
       const spy = spyOn(queueGateway, 'updateSubstituteRequests');
       const game = await service.cancelSubstitutionRequest('FAKE_GAME_ID', 'FAKE_PLAYER_1');
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('should do nothing if the player is already marked', async () => {
+      const game1 = await service.cancelSubstitutionRequest('FAKE_GAME_ID', 'FAKE_PLAYER_1');
+      const game2 = await service.cancelSubstitutionRequest('FAKE_GAME_ID', 'FAKE_PLAYER_1');
+      expect(game1).toEqual(game2);
     });
   });
 
@@ -308,6 +320,12 @@ describe('PlayerSubstitutionService', () => {
 
     it('should reject if the replacement player does not exist', async () => {
       await expectAsync(service.replacePlayer('FAKE_GAME_ID', 'FAKE_PLAYER_1', 'some nonexistent player id')).toBeRejectedWithError('no such player');
+    });
+
+    it('should reject if the replacement player is involved in an active game', async () => {
+      spyOn(gamesService, 'getPlayerActiveGame').and.returnValue(new Promise(resolve => resolve(mockGame)));
+      await expectAsync(service.replacePlayer('FAKE_GAME_ID', 'FAKE_PLAYER_1', 'FAKE_PLAYER_3'))
+        .toBeRejectedWithError('player is involved in a currently running game');
     });
   });
 

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -127,6 +127,7 @@ export class PlayerSubstitutionService {
         playerId: replacementId,
         teamId: slot.teamId,
         gameClass: slot.gameClass,
+        status: 'active',
       };
 
       game.slots.push(replacementSlot);

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -109,23 +109,29 @@ export class PlayerSubstitutionService {
       return game;
     }
 
-    if (await this.gamesService.getPlayerActiveGame(replacementId)) {
+    if (!!await this.gamesService.getPlayerActiveGame(replacementId)) {
       throw new Error('player is involved in a currently running game');
     }
 
     const replacement = await this.playersService.getById(replacementId);
+    if (!replacement) {
+      throw new Error('no such player');
+    }
 
-    // create new slot of the replacement player
-    const replacementSlot: GamePlayer = {
-      playerId: replacementId,
-      teamId: slot.teamId,
-      gameClass: slot.gameClass,
-      status: 'active',
-      connectionStatus: 'offline',
-    };
+    let replacementSlot: GamePlayer = game.slots.find(s => s.playerId === replacementId);
+    if (replacementSlot) {
+      replacementSlot.status = 'active';
+    } else {
+      // create new slot of the replacement player
+      replacementSlot = {
+        playerId: replacementId,
+        teamId: slot.teamId,
+        gameClass: slot.gameClass,
+      };
 
-    game.slots.push(replacementSlot);
-    game.players.push(replacement);
+      game.slots.push(replacementSlot);
+      game.players.push(replacement);
+    }
 
     // update replacee
     slot.status = 'replaced';


### PR DESCRIPTION
A couple of fixes:
* replaced players are no longer considered in-game;
* player can subsitute in a game he was replaced from beforehand.