### PR TITLE
fix: downgrade cp_reckoner to version rc2

### DIFF
--- a/configs/queue/6v6.json
+++ b/configs/queue/6v6.json
@@ -24,7 +24,7 @@
     "cp_sunshine",
     "cp_granary_pro_rc8",
     "cp_gullywash_final1",
-    "cp_reckoner_rc5",
+    "cp_reckoner_rc2",
     "cp_prolands_rc2t"
   ],
   "execConfigs": [


### PR DESCRIPTION
From ETF2L discord:
> Due to unresolved map issues coupled with the map maker being unreachable, we have decided that cp_reckoner_rc5 will be replaced with rc2 for the remainder of the season. The reason rc2 was chosen over other versions was due to it featuring in previous ETF2L seasons.