### PR TITLE
fix: handle missing execConfigs option

### DIFF
--- a/src/games/services/server-configurator.service.spec.ts
+++ b/src/games/services/server-configurator.service.spec.ts
@@ -29,7 +29,6 @@ class QueueConfigServiceStub {
     configs: {
       '5cp': 'etf2l_6v6_5cp',
     },
-    execConfigs: [ 'test' ],
   } as Partial<QueueConfig>;
 }
 
@@ -106,7 +105,6 @@ describe('ServerConfiguratorService', () => {
       expect(spy).toHaveBeenCalledWith(kickAll());
       expect(spy).toHaveBeenCalledWith(changelevel('cp_badlands'));
       expect(spy).toHaveBeenCalledWith(execConfig('etf2l_6v6_5cp'));
-      expect(spy).toHaveBeenCalledWith(execConfig('test'));
       expect(spy).toHaveBeenCalledWith(jasmine.stringMatching(/^sv_password\s.+$/));
       expect(spy).toHaveBeenCalledWith(addGamePlayer('PLAYER_1_STEAMID', 'PLAYER_1_NAME', 2, 'soldier'));
       expect(spy).toHaveBeenCalledWith(addGamePlayer('PLAYER_2_STEAMID', 'PLAYER_2_NAME', 3, 'soldier'));
@@ -124,6 +122,18 @@ describe('ServerConfiguratorService', () => {
         const spy = jest.spyOn(rcon, 'send');
         await service.configureServer(gameServer as any, game as any);
         expect(spy).toHaveBeenCalledWith(tftrueWhitelistId('FAKE_WHITELIST_ID'));
+      });
+    });
+
+    describe('when the execConfigs is set', () => {
+      beforeEach(() => {
+        queueConfigService.queueConfig.execConfigs = [ 'test' ];
+      });
+
+      it('should execute the configs', async () => {
+        const spy = jest.spyOn(rcon, 'send');
+        await service.configureServer(gameServer as any, game as any);
+        expect(spy).toHaveBeenCalledWith(execConfig('test'));
       });
     });
 

--- a/src/games/services/server-configurator.service.ts
+++ b/src/games/services/server-configurator.service.ts
@@ -48,9 +48,11 @@ export class ServerConfiguratorService {
         await rcon.send(execConfig(config));
       }
 
-      for (const c of this.queueConfigService.queueConfig.execConfigs) {
-        this.logger.debug(`[${server.name}] executing ${c}...`);
-        await rcon.send(execConfig(c));
+      if (this.queueConfigService.queueConfig.execConfigs) {
+        for (const c of this.queueConfigService.queueConfig.execConfigs) {
+          this.logger.debug(`[${server.name}] executing ${c}...`);
+          await rcon.send(execConfig(c));
+        }
       }
 
       if (this.queueConfigService.queueConfig.whitelistId) {


### PR DESCRIPTION
Handle the lack of `execConfigs` option in the gamemode configuration file.