### PR TITLE
feat: map cooldown

### DIFF
--- a/configs/config.ts
+++ b/configs/config.ts
@@ -23,6 +23,12 @@ export default () => ({
      * Default: 60 * 1000 (1 minute).
      */
     readyStateTimeout: 60 * 1000,
+
+    /**
+     * How many times the last played map cannot be an option to vote for.
+     * Default: 2
+     */
+    mapCooldown: 2,
   },
 
   /**


### PR DESCRIPTION
Implements a map cooldown feature that keeps a map from being made an option to vote for for a specified number of times.