### PR TITLE
feat: notify admins on name change

### DIFF
--- a/src/discord/services/discord-notifications.service.spec.ts
+++ b/src/discord/services/discord-notifications.service.spec.ts
@@ -171,7 +171,7 @@ describe('DiscordNotificationsService', () => {
     });
 
     describe('#notifyPlayerBanAdded()', () => {
-      it('should send a notification to the queue channel', async () => {
+      it('should send a notification to the admin channel', async () => {
         const spy = jest.spyOn(adminChannel, 'send');
         await service.notifyPlayerBanAdded({ player: new ObjectId(), admin: new ObjectId(), start: new Date(),
             end: new Date(), _id: new ObjectId().toString() });
@@ -180,7 +180,7 @@ describe('DiscordNotificationsService', () => {
     });
 
     describe('#notifyPlayerBanRevoked()', () => {
-      it('should send a notification to the queue channel', async () => {
+      it('should send a notification to the admin channel', async () => {
         const spy = jest.spyOn(adminChannel, 'send');
         await service.notifyPlayerBanRevoked({ player: new ObjectId(), admin: new ObjectId(), start: new Date(),
             end: new Date(), _id: new ObjectId().toString() });
@@ -189,9 +189,17 @@ describe('DiscordNotificationsService', () => {
     });
 
     describe('#notifyNewPlayer()', () => {
-      it('should send a notification to the queue channel', async () => {
+      it('should send a notification to the admin channel', async () => {
         const spy = jest.spyOn(adminChannel, 'send');
         await service.notifyNewPlayer({ id: 'FAKE_PLAYER_ID', name: 'FAKE_PLAYER', steamId: 'FAKE_STEAM_ID', hasAcceptedRules: true });
+        expect(spy).toHaveBeenCalledWith(expect.any(MessageEmbed));
+      });
+    });
+
+    describe('#notifyNameChange()', () => {
+      it('should send a notification to the admin channel', async () => {
+        const spy = jest.spyOn(adminChannel, 'send');
+        await service.notifyNameChange({ id: 'FAKE_PLAYER_ID', name: 'FAKE_PLAYER', steamId: 'FAKE_STEAM_ID', hasAcceptedRules: true }, 'OLD_NAME');
         expect(spy).toHaveBeenCalledWith(expect.any(MessageEmbed));
       });
     });

--- a/src/discord/services/discord-notifications.service.ts
+++ b/src/discord/services/discord-notifications.service.ts
@@ -101,6 +101,10 @@ export class DiscordNotificationsService implements OnModuleInit {
     return this.sendNotification(TargetChannel.Admins, await this.messageEmbedFactoryService.fromNewPlayer(player));
   }
 
+  async notifyNameChange(player: Player, oldName: string) {
+    return this.sendNotification(TargetChannel.Admins, await this.messageEmbedFactoryService.fromNameChange(player, oldName));
+  }
+
   private enable() {
     this.guild = this.client.guilds.cache.find(guild => guild.name === this.environment.discordGuild);
     if (this.guild?.available) {

--- a/src/discord/services/message-embed-factory.service.spec.ts
+++ b/src/discord/services/message-embed-factory.service.spec.ts
@@ -90,6 +90,20 @@ describe('MessageEmbedFactoryService', () => {
     });
   });
 
+  describe('fromNameChange()', () => {
+    it('should render the MessageEmbed', async () => {
+      const ret = await service.fromNameChange({ name: 'FAKE_PLAYER', id: 'FAKE_PLAYER_ID' } as any, 'OLD_NAME');
+
+      expect(ret.title).toEqual('Player name changed');
+      expect(ret.fields).toEqual([
+        { name: 'Old name', value: 'OLD_NAME', inline: false },
+        { name: 'New name', value: 'FAKE_PLAYER', inline: false },
+        { name: 'Profile URL', value: 'FAKE_CLIENT_URL/player/FAKE_PLAYER_ID', inline: false },
+      ]);
+      expect(ret.timestamp).toBeTruthy();
+    });
+  });
+
   describe('fromSubstituteRequest()', () => {
     it('should render the MessageEmbed', async () => {
       const ret = await service.fromSubstituteRequest({

--- a/src/discord/services/message-embed-factory.service.ts
+++ b/src/discord/services/message-embed-factory.service.ts
@@ -50,6 +50,16 @@ export class MessageEmbedFactoryService {
       .setTimestamp();
   }
 
+  async fromNameChange(player: Player, oldName: string) {
+    return new MessageEmbed()
+      .setColor('#5230dc')
+      .setTitle('Player name changed')
+      .addField('Old name', oldName)
+      .addField('New name', player.name)
+      .addField('Profile URL', `${this.environment.clientUrl}/player/${player.id}`)
+      .setTimestamp();
+  }
+
   async fromSubstituteRequest(substituteRequest: SubstituteRequest) {
     return new MessageEmbed()
       .setColor('#ff557f')

--- a/src/players/services/players.service.spec.ts
+++ b/src/players/services/players.service.spec.ts
@@ -52,7 +52,8 @@ class OnlinePlayersServiceStub {
 }
 
 class DiscordNotificationsServiceStub {
-  notifyNewPlayer(player: any) { return null; }
+  notifyNewPlayer(player: any) { return Promise.resolve(); }
+  notifyNameChange(player: any, oldName: string) { return Promise.resolve(); }
 }
 
 class ConfigServiceStub {
@@ -273,6 +274,12 @@ describe('PlayersService', () => {
     it('should return null if the given player does not exist', async () => {
       jest.spyOn(service, 'getById').mockResolvedValue(null);
       expect(await service.updatePlayer('FAKE_ID', { })).toBeNull();
+    });
+
+    it('should notify admins on Discord', async () => {
+      const spy = jest.spyOn(discordNotificationsService, 'notifyNameChange');
+      await service.updatePlayer(mockPlayer.id, { name: 'NEW_NAME' });
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ name: 'NEW_NAME' }), 'FAKE_PLAYER_NAME');
     });
   });
 

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -101,7 +101,9 @@ export class PlayersService {
     const player = await this.getById(playerId);
     if (player) {
       if (update.name) {
+        const oldName = player.name;
         player.name = update.name;
+        this.discordNotificationsService.notifyNameChange(player, oldName);
       }
 
       if (update.role !== undefined) {


### PR DESCRIPTION
Send notifications to the admins' channel whenever a player's name gets changed.