### PR TITLE
fix: ignore match start after it has been ended

### DIFF
--- a/src/games/services/games.service.spec.ts
+++ b/src/games/services/games.service.spec.ts
@@ -124,27 +124,6 @@ describe('GamesService', () => {
     });
   });
 
-  describe('#update()', () => {
-    let game: DocumentType<Game>;
-
-    beforeEach(async () => {
-      game = await gameModel.create({ number: 1, map: 'cp_badlands', state: 'launching' });
-    });
-
-    it('should update existing game', async () => {
-      const ret = await service.update(game.id, { state: 'started' });
-      expect(ret.state).toEqual('started');
-      expect(ret).toEqual(await service.getById(game.id));
-    });
-
-    it('should not create a new game in case of missing id', async () => {
-      const wrongGameId = new ObjectId();
-      const ret = await service.update(wrongGameId.toString(), { state: 'started' });
-      expect(ret).toBe(null);
-      expect(await service.getById(wrongGameId.toString())).toBe(null);
-    });
-  });
-
   describe('#findByAssignedGameServer()', () => {
     let gameServerId: ObjectId;
     let game: DocumentType<Game>;

--- a/src/games/services/games.service.ts
+++ b/src/games/services/games.service.ts
@@ -10,6 +10,7 @@ import { QueueConfigService } from '@/queue/services/queue-config.service';
 import { GameLauncherService } from './game-launcher.service';
 import { GamesGateway } from '../gateways/games.gateway';
 import { ObjectId } from 'mongodb';
+import { FilterQuery } from 'mongoose';
 
 interface GameSortOptions {
   launchedAt: 1 | -1;
@@ -43,10 +44,6 @@ export class GamesService {
 
   async getRunningGames(): Promise<DocumentType<Game>[]> {
     return await this.gameModel.find({ state: /launching|started/ });
-  }
-
-  async update(gameId: string, update: Partial<Game>) {
-    return await this.gameModel.findByIdAndUpdate(gameId, update, { new: true });
   }
 
   async findByAssignedGameServer(gameServerId: string): Promise<DocumentType<Game>> {


### PR DESCRIPTION
The game server happens to send the Round_Start event right after
Round_End was sent. This might mark the given game as started again.