### PR TITLE
refactor!: update Game model to use team names

### DIFF
--- a/.migrate
+++ b/.migrate
@@ -1,0 +1,9 @@
+{
+  "lastRun": "1592050029364-use-tf2-team-names.js",
+  "migrations": [
+    {
+      "title": "1592050029364-use-tf2-team-names.js",
+      "timestamp": 1592050148283
+    }
+  ]
+}

--- a/migrations/1592050029364-use-tf2-team-names.js
+++ b/migrations/1592050029364-use-tf2-team-names.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const mongodb = require('mongodb');
+require('dotenv').config();
+
+let credentials = '';
+if (process.env.MONGODB_USERNAME) {
+  if (process.env.MONGODB_PASSWORD) {
+    credentials = `${process.env.MONGODB_USERNAME}:${process.env.MONGODB_PASSWORD}@`;
+  } else {
+    credentials = `${process.env.MONGODB_USERNAME}@`;
+  }
+}
+
+const uri = `mongodb://${credentials}${process.env.MONGODB_HOST}:${process.env.MONGODB_PORT}/${process.env.MONGODB_DB}`;
+
+module.exports.up = function (next) {
+  mongodb.MongoClient.connect(uri, { useUnifiedTopology: true })
+    .then(client => client.db())
+    .then(db => {
+      const Games = db.collection('games');
+      return Games.find().forEach(game => {
+        game.slots.forEach(slot => {
+          if (!slot.team) {
+            slot.team = game.teams[slot.teamId].toLowerCase();
+          }
+        });
+
+        return Games.save(game);
+      });
+    })
+    .then(next);
+}
+
+module.exports.down = next => {
+  next()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7836,6 +7836,14 @@
       "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
       "dev": true
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -11853,6 +11861,68 @@
         "picomatch": "^2.0.5"
       }
     },
+    "migrate": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/migrate/-/migrate-1.6.2.tgz",
+      "integrity": "sha512-XAFab+ArPTo9BHzmihKjsZ5THKRryenA+lwob0R+ax0hLDs7YzJFJT5YZE3gtntZgzdgcuFLs82EJFB/Dssr+g==",
+      "requires": {
+        "chalk": "^1.1.3",
+        "commander": "^2.9.0",
+        "dateformat": "^2.0.0",
+        "dotenv": "^4.0.0",
+        "inherits": "^2.0.3",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^0.5.1",
+        "slug": "^0.9.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+        },
+        "dotenv": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+          "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -14834,6 +14904,14 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
+    "slug": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.4.tgz",
+      "integrity": "sha512-3YHq0TeJ4+AIFbJm+4UWSQs5A1mmeWOTQqydW3OoPmQfNKxlO96NDRTIrp+TBkmvEsEFrd+Z/LXw8OD/6OlZ5g==",
+      "requires": {
+        "unicode": ">= 0.3.1"
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -16318,6 +16396,11 @@
           "optional": true
         }
       }
+    },
+    "unicode": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/unicode/-/unicode-12.1.0.tgz",
+      "integrity": "sha512-Ty6+Ew21DiYTWLYtd05RF/X4c1ekOvOgANyHbBj0h3MaXpfaGr2Rdmc0hMFuGQLyPLb9cU4ArNxl0bTF5HSzXw=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "dev": "nest start --watch --debug",
     "prod": "node dist/main",
     "lint": "tslint -p tsconfig.json -c tslint.json",
-    "test": "jest",
+    "test": "jest --watch",
     "test:ci": "jest --ci --maxWorkers 4",
     "console": "ts-node -r tsconfig-paths/register src/console.ts",
     "export-skills": "ts-node -r tsconfig-paths/register src/console.ts -- export-skills",
-    "release": "release-it"
+    "release": "release-it",
+    "migrate": "migrate"
   },
   "dependencies": {
     "@hapi/joi": "17.1.1",
@@ -27,8 +28,8 @@
     "@nestjs/platform-express": "7.1.3",
     "@nestjs/platform-socket.io": "7.1.3",
     "@nestjs/schedule": "0.4.0",
-    "@nestjs/websockets": "7.1.3",
     "@nestjs/serve-static": "2.1.1",
+    "@nestjs/websockets": "7.1.3",
     "@typegoose/typegoose": "7.2.0",
     "class-transformer": "0.2.3",
     "class-validator": "0.12.2",
@@ -40,6 +41,7 @@
     "jsonschema": "1.2.6",
     "jsonwebtoken": "8.5.1",
     "lodash": "4.17.15",
+    "migrate": "^1.6.2",
     "moment": "2.26.0",
     "mongoose": "5.9.18",
     "nestjs-console": "3.0.6",

--- a/src/games/models/game-player.ts
+++ b/src/games/models/game-player.ts
@@ -1,14 +1,16 @@
 import { prop, index } from '@typegoose/typegoose';
 import { PlayerConnectionStatus } from './player-connection-status';
+import { Tf2Team } from './tf2-team';
 
 @index({ playerId: 1 })
 @index({ status: 1 })
 export class GamePlayer {
+
   @prop({ required: true })
   playerId!: string;
 
-  @prop({ required: true })
-  teamId!: string;
+  @prop({ required: true, enum: Tf2Team })
+  team!: Tf2Team;
 
   @prop({ required: true })
   gameClass!: string;
@@ -18,4 +20,5 @@ export class GamePlayer {
 
   @prop({ default: 'offline' })
   connectionStatus?: PlayerConnectionStatus;
+
 }

--- a/src/games/models/game.ts
+++ b/src/games/models/game.ts
@@ -9,14 +9,12 @@ type GameState = 'launching' | 'started' | 'ended' | 'interrupted';
 @index({ players: 1 })
 @index({ gameServer: 1 })
 export class Game {
+
   @prop({ default: () => new Date() })
   launchedAt?: Date;
 
   @prop({ required: true, unique: true })
   number!: number;
-
-  @mapProp({ of: String })
-  teams?: Map<string, string>;
 
   @arrayProp({ ref: 'Player' })
   players?: Ref<Player>[];
@@ -53,4 +51,5 @@ export class Game {
 
   @prop()
   stvConnectString?: string;
+
 }

--- a/src/games/models/tf2-team.ts
+++ b/src/games/models/tf2-team.ts
@@ -1,0 +1,4 @@
+export enum Tf2Team {
+  Red = 'red',
+  Blu = 'blu',
+};

--- a/src/games/services/__mocks__/games.service.ts
+++ b/src/games/services/__mocks__/games.service.ts
@@ -25,16 +25,13 @@ export class GamesService {
 
   async _createOne(players: Player[]) {
     let lastTeamId = 0;
+    const teams = [ 'red', 'blu' ];
     return await this.gameModel.create({
       number: ++this.lastGameId,
       map: 'cp_badlands',
-      teams: {
-        0: 'RED',
-        1: 'BLU',
-      },
       slots: players.map(p => ({
         playerId: p.id,
-        teamId: `${(lastTeamId++) % 2}`,
+        team: teams[`${(lastTeamId++) % 2}`],
         gameClass: 'soldier',
       })),
       players,

--- a/src/games/services/game-event-handler.service.spec.ts
+++ b/src/games/services/game-event-handler.service.spec.ts
@@ -223,11 +223,11 @@ describe('GameEventHandlerService', () => {
     it('should update the game\'s score', async () => {
       await service.onScoreReported(mockGame.id, 'Red', '2');
       let game = await gamesService.getById(mockGame.id);
-      expect(game.score.get('0')).toEqual(2);
+      expect(game.score.get('red')).toEqual(2);
 
       await service.onScoreReported(mockGame.id, 'Blue', '5');
       game = await gamesService.getById(mockGame.id);
-      expect(game.score.get('1')).toEqual(5);
+      expect(game.score.get('blu')).toEqual(5);
     });
 
     it('should emit an event over ws', async () => {

--- a/src/games/services/game-runtime.service.ts
+++ b/src/games/services/game-runtime.service.ts
@@ -88,9 +88,8 @@ export class GameRuntimeService {
     try {
       rcon = await this.rconFactoryService.createRcon(gameServer);
       const player = await this.playersService.getById(replacementSlot.playerId);
-      const team = parseInt(replacementSlot.teamId, 10) + 2;
 
-      const cmd = addGamePlayer(player.steamId, player.name, team, replacementSlot.gameClass);
+      const cmd = addGamePlayer(player.steamId, player.name, replacementSlot.team, replacementSlot.gameClass);
       this.logger.debug(cmd);
       await rcon.send(cmd);
 

--- a/src/games/services/games.service.spec.ts
+++ b/src/games/services/games.service.spec.ts
@@ -12,11 +12,13 @@ import { QueueSlot } from '@/queue/queue-slot';
 import { GameLauncherService } from './game-launcher.service';
 import { QueueConfigService } from '@/queue/services/queue-config.service';
 import { GamesGateway } from '../gateways/games.gateway';
-import { cloneDeep } from 'lodash';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import { Tf2Team } from '../models/tf2-team';
 
 jest.mock('@/players/services/players.service');
 jest.mock('@/players/services/player-skill.service');
+jest.mock('./game-launcher.service');
+jest.mock('../gateways/games.gateway');
 
 class QueueConfigServiceStub {
   queueConfig = {
@@ -33,20 +35,11 @@ class QueueConfigServiceStub {
   };
 }
 
-class GameLauncherServiceStub {
-  launch(gameId: string) { return null; }
-}
-
-class GamesGatewayStub {
-  emitGameCreated(game: any) { return null; }
-  emitGameUpdated(game: any) { return null; }
-}
-
 describe('GamesService', () => {
   let service: GamesService;
   let mongod: MongoMemoryServer;
   let gameModel: ReturnModelType<typeof Game>;
-  let gameLauncherService: GameLauncherServiceStub;
+  let gameLauncherService: GameLauncherService;
   let playersService: PlayersService;
 
   beforeAll(() => mongod = new MongoMemoryServer());
@@ -63,8 +56,8 @@ describe('GamesService', () => {
         PlayersService,
         PlayerSkillService,
         { provide: QueueConfigService, useClass: QueueConfigServiceStub },
-        { provide: GameLauncherService, useClass: GameLauncherServiceStub },
-        { provide: GamesGateway, useClass: GamesGatewayStub },
+        GameLauncherService,
+        GamesGateway,
       ],
     }).compile();
 
@@ -156,7 +149,7 @@ describe('GamesService', () => {
               playerId: playerId.toString(),
               status: 'active',
               gameClass: 'soldier',
-              teamId: '1',
+              team: Tf2Team.Blu,
             },
           ],
         });
@@ -185,7 +178,7 @@ describe('GamesService', () => {
               playerId: playerId.toString(),
               status: 'waiting for substitute',
               gameClass: 'soldier',
-              teamId: '1',
+              team: Tf2Team.Blu,
             },
           ],
         });
@@ -216,13 +209,13 @@ describe('GamesService', () => {
               playerId: playerId.toString(),
               status: 'replaced',
               gameClass: 'soldier',
-              teamId: '1',
+              team: Tf2Team.Blu,
             },
             {
               playerId: player2Id.toString(),
               status: 'active',
               gameClass: 'soldier',
-              teamId: '2',
+              team: Tf2Team.Red,
             },
           ],
         });
@@ -249,7 +242,7 @@ describe('GamesService', () => {
               playerId: playerId.toString(),
               status: 'active',
               gameClass: 'soldier',
-              teamId: '1',
+              team: Tf2Team.Blu,
             },
           ],
         });
@@ -341,13 +334,13 @@ describe('GamesService', () => {
         slots: [
           {
             playerId: player1.toString(),
-            teamId: '1',
+            team: Tf2Team.Blu,
             gameClass: 'scout',
             status: 'waiting for substitute',
           },
           {
             playerId: player2.toString(),
-            teamId: '2',
+            team: Tf2Team.Red,
             gameClass: 'scout',
             status: 'active',
           },

--- a/src/games/services/games.service.ts
+++ b/src/games/services/games.service.ts
@@ -11,6 +11,7 @@ import { GameLauncherService } from './game-launcher.service';
 import { GamesGateway } from '../gateways/games.gateway';
 import { ObjectId } from 'mongodb';
 import { FilterQuery } from 'mongoose';
+import { shuffle } from 'lodash';
 
 interface GameSortOptions {
   launchedAt: 1 | -1;
@@ -113,16 +114,12 @@ export class GamesService {
 
     const players: PlayerSlot[] = await Promise.all(queueSlots.map(slot => this.queueSlotToPlayerSlot(slot)));
     const assignedSkills = players.reduce((prev, curr) => { prev[curr.playerId] = curr.skill; return prev; }, { });
-    const slots = pickTeams(players, this.queueConfigService.queueConfig.classes.map(cls => cls.name), { friends });
+    const slots = pickTeams(shuffle(players), { friends });
     const gameNo = await this.getNextGameNumber();
 
     const game = await this.gameModel.create({
       number: gameNo,
       map,
-      teams: {
-        0: 'RED',
-        1: 'BLU',
-      },
       slots,
       players: queueSlots.map(s => new ObjectId(s.playerId)),
       assignedSkills,

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -63,7 +63,7 @@ export class PlayerSubstitutionService {
       embed:substituteRequest({
         gameNumber: game.number,
         gameClass: slot.gameClass,
-        team: game.teams.get(slot.teamId),
+        team: slot.team.toUpperCase(),
         gameUrl: `${this.environment.clientUrl}/game/${game.id}`,
       }),
     });
@@ -144,7 +144,7 @@ export class PlayerSubstitutionService {
       // create new slot of the replacement player
       replacementSlot = {
         playerId: replacementId,
-        teamId: slot.teamId,
+        team: slot.team,
         gameClass: slot.gameClass,
         status: 'active',
       };

--- a/src/games/services/server-configurator.service.spec.ts
+++ b/src/games/services/server-configurator.service.spec.ts
@@ -7,6 +7,7 @@ import { RconFactoryService } from './rcon-factory.service';
 import { logAddressAdd, kickAll, changelevel, execConfig, addGamePlayer, enablePlayerWhitelist, tvPort, tvPassword,
   logAddressDel, delAllGamePlayers, disablePlayerWhitelist, tftrueWhitelistId } from '../utils/rcon-commands';
 import { QueueConfig } from '@/queue/queue-config';
+import { Tf2Team } from '../models/tf2-team';
 
 class EnvironmentStub {
   logRelayAddress = 'FAKE_RELAY_ADDRESS';
@@ -50,12 +51,12 @@ const game = {
   slots: [
     {
       playerId: 'PLAYER_1',
-      teamId: 0,
+      team: Tf2Team.Blu,
       gameClass: 'soldier',
     },
     {
       playerId: 'PLAYER_2',
-      teamId: 1,
+      team: Tf2Team.Red,
       gameClass: 'soldier',
     },
   ],
@@ -106,8 +107,8 @@ describe('ServerConfiguratorService', () => {
       expect(spy).toHaveBeenCalledWith(changelevel('cp_badlands'));
       expect(spy).toHaveBeenCalledWith(execConfig('etf2l_6v6_5cp'));
       expect(spy).toHaveBeenCalledWith(jasmine.stringMatching(/^sv_password\s.+$/));
-      expect(spy).toHaveBeenCalledWith(addGamePlayer('PLAYER_1_STEAMID', 'PLAYER_1_NAME', 2, 'soldier'));
-      expect(spy).toHaveBeenCalledWith(addGamePlayer('PLAYER_2_STEAMID', 'PLAYER_2_NAME', 3, 'soldier'));
+      expect(spy).toHaveBeenCalledWith(addGamePlayer('PLAYER_1_STEAMID', 'PLAYER_1_NAME', Tf2Team.Blu, 'soldier'));
+      expect(spy).toHaveBeenCalledWith(addGamePlayer('PLAYER_2_STEAMID', 'PLAYER_2_NAME', Tf2Team.Red, 'soldier'));
       expect(spy).toHaveBeenCalledWith(enablePlayerWhitelist());
       expect(spy).toHaveBeenCalledWith(tvPort());
       expect(spy).toHaveBeenCalledWith(tvPassword());
@@ -148,7 +149,7 @@ describe('ServerConfiguratorService', () => {
       const spy = jest.spyOn(rcon, 'send');
 
       await service.configureServer(gameServer as any, game as any);
-      expect(spy).toHaveBeenCalledWith(addGamePlayer('PLAYER_1_STEAMID', 'maly', 2, 'soldier'));
+      expect(spy).toHaveBeenCalledWith(addGamePlayer('PLAYER_1_STEAMID', 'maly', Tf2Team.Blu, 'soldier'));
     });
 
     it('should close the rcon connection even though an RCON command failed', async () => {

--- a/src/games/services/server-configurator.service.ts
+++ b/src/games/services/server-configurator.service.ts
@@ -66,10 +66,9 @@ export class ServerConfiguratorService {
 
       for (const slot of game.slots) {
         const player = await this.playersService.getById(slot.playerId);
-        const team = parseInt(slot.teamId, 10) + 2;
 
         const playerName = deburr(player.name);
-        const cmd = addGamePlayer(player.steamId, playerName, team, slot.gameClass);
+        const cmd = addGamePlayer(player.steamId, playerName, slot.team, slot.gameClass);
         this.logger.debug(`[${server.name}] ${cmd}`);
         await rcon.send(cmd);
       }

--- a/src/games/utils/pick-teams.spec.ts
+++ b/src/games/utils/pick-teams.spec.ts
@@ -1,181 +1,187 @@
 import { pickTeams, PlayerSlot, TeamOverrides } from './pick-teams';
 
 describe('pickTeams', () => {
-  describe('without team overrides', () => {
-    it('should pick teams for 4 slots', () => {
-      const players: PlayerSlot[] = [
-        { playerId: '0', gameClass: 'soldier', skill: 1 },
-        { playerId: '1', gameClass: 'soldier', skill: 2 },
-        { playerId: '2', gameClass: 'soldier', skill: 3 },
-        { playerId: '3', gameClass: 'soldier', skill: 4 },
-      ];
-      const gameClasses = ['soldier'];
+  describe('for 2v2', () => {
+    const playerIds: PlayerSlot[] = [
+      { playerId: 'a', gameClass: 'soldier', skill: 1 },
+      { playerId: 'b', gameClass: 'soldier', skill: 2 },
+      { playerId: 'c', gameClass: 'soldier', skill: 3 },
+      { playerId: 'd', gameClass: 'soldier', skill: 4 },
+    ];
 
-      const gamePlayers = pickTeams(players, gameClasses);
-      expect(gamePlayers.length).toBe(4);
-      expect(gamePlayers.filter(p => p.teamId === '0').length).toBe(2);
-      expect(gamePlayers.filter(p => p.teamId === '1').length).toBe(2);
-
-      expect(gamePlayers.find(p => p.playerId === '0').teamId)
-        .toEqual(gamePlayers.find(p => p.playerId === '3').teamId);
-
-      expect(gamePlayers.find(p => p.playerId === '1').teamId)
-        .toEqual(gamePlayers.find(p => p.playerId === '2').teamId);
+    it('should pick teams', () => {
+      expect(pickTeams(playerIds)).toEqual([
+        { playerId: 'a', gameClass: 'soldier', skill: 1, team: 'blu' },
+        { playerId: 'd', gameClass: 'soldier', skill: 4, team: 'blu' },
+        { playerId: 'b', gameClass: 'soldier', skill: 2, team: 'red' },
+        { playerId: 'c', gameClass: 'soldier', skill: 3, team: 'red' },
+      ]);
     });
 
-    it('should pick teams for 12 slots', () => {
-      const players: PlayerSlot[] = [
-        { playerId: '0', gameClass: 'scout', skill: 2 },
-        { playerId: '1', gameClass: 'scout', skill: 2 },
-        { playerId: '2', gameClass: 'scout', skill: 2 },
-        { playerId: '3', gameClass: 'scout', skill: 2 },
-        { playerId: '4', gameClass: 'soldier', skill: 4 },
-        { playerId: '5', gameClass: 'soldier', skill: 4 },
-        { playerId: '6', gameClass: 'soldier', skill: 5 },
-        { playerId: '7', gameClass: 'soldier', skill: 4 },
-        { playerId: '0', gameClass: 'demoman', skill: 1 },
-        { playerId: '1', gameClass: 'demoman', skill: 3 },
-        { playerId: '2', gameClass: 'medic', skill: 2 },
-        { playerId: '3', gameClass: 'medic', skill: 4 },
-      ];
-      const gameClasses = ['scout', 'soldier', 'demoman', 'medic'];
-      const gamePlayers = pickTeams(players, gameClasses);
+    describe('with friends', () => {
+      describe('having all the friends valid', () => {
+        const overrides: TeamOverrides = {
+          friends: [
+            [ 'a', 'c' ], // 'a' and 'c' will be in the same team
+          ],
+        };
 
-      expect(gamePlayers.filter(p => p.teamId === '0').length).toBe(6);
-      expect(gamePlayers.filter(p => p.teamId === '1').length).toBe(6);
-    });
+        it('should pick teams', () => {
+          expect(pickTeams(playerIds, overrides)).toEqual([
+            { playerId: 'a', gameClass: 'soldier', skill: 1, team: 'blu' },
+            { playerId: 'c', gameClass: 'soldier', skill: 3, team: 'blu' },
+            { playerId: 'b', gameClass: 'soldier', skill: 2, team: 'red' },
+            { playerId: 'd', gameClass: 'soldier', skill: 4, team: 'red' },
+          ]);
+        });
+      });
 
-    it('should pick teams for 18 slots', () => {
-      const players: PlayerSlot[] = [
-        { playerId: '0', gameClass: 'scout', skill: 1 },
-        { playerId: '1', gameClass: 'scout', skill: 9 },
-        { playerId: '2', gameClass: 'soldier', skill: 2 },
-        { playerId: '3', gameClass: 'soldier', skill: 8 },
-        { playerId: '4', gameClass: 'pyro', skill: 3 },
-        { playerId: '5', gameClass: 'pyro', skill: 7 },
-        { playerId: '6', gameClass: 'demoman', skill: 4 },
-        { playerId: '7', gameClass: 'demoman', skill: 6 },
-        { playerId: '8', gameClass: 'heavy', skill: 5 },
-        { playerId: '9', gameClass: 'heavy', skill: 5 },
-        { playerId: '10', gameClass: 'engineer', skill: 6 },
-        { playerId: '11', gameClass: 'engineer', skill: 4 },
-        { playerId: '12', gameClass: 'medic', skill: 7 },
-        { playerId: '13', gameClass: 'medic', skill: 3 },
-        { playerId: '14', gameClass: 'sniper', skill: 8 },
-        { playerId: '15', gameClass: 'sniper', skill: 2 },
-        { playerId: '16', gameClass: 'spy', skill: 9 },
-        { playerId: '17', gameClass: 'spy', skill: 1 },
-      ];
-      const gameClasses = ['scout', 'soldier', 'pyro', 'demoman', 'heavy', 'engineer', 'medic', 'sniper', 'spy'];
-      const gamePlayers = pickTeams(players, gameClasses);
+      describe('missing one friend', () => {
+        const overrides: TeamOverrides = {
+          friends: [
+            [ 'a', 'e' ],
+          ],
+        };
 
-      expect(gamePlayers.filter(p => p.teamId === '0').length).toBe(9);
-      expect(gamePlayers.filter(p => p.teamId === '1').length).toBe(9);
-    });
-
-    it('should pick teams with minimum skill difference possible', () => {
-      const players: PlayerSlot[] = [
-        { playerId: '0', gameClass: 'scout', skill: 1 },
-        { playerId: '1', gameClass: 'scout', skill: 1 },
-        { playerId: '2', gameClass: 'scout', skill: 1 },
-        { playerId: '3', gameClass: 'scout', skill: 1 },
-        { playerId: '4', gameClass: 'soldier', skill: 1 },
-        { playerId: '5', gameClass: 'soldier', skill: 1 },
-        { playerId: '6', gameClass: 'soldier', skill: 5 },
-        { playerId: '7', gameClass: 'soldier', skill: 1 },
-        { playerId: '8', gameClass: 'demoman', skill: 1 },
-        { playerId: '9', gameClass: 'demoman', skill: 1 },
-        { playerId: '10', gameClass: 'medic', skill: 3 },
-        { playerId: '11', gameClass: 'medic', skill: 1 },
-      ];
-      const gameClasses = ['scout', 'soldier', 'demoman', 'medic'];
-      const gamePlayers = pickTeams(players, gameClasses);
-
-      expect(gamePlayers.filter(p => p.teamId === '0').length).toBe(6);
-      expect(gamePlayers.filter(p => p.teamId === '1').length).toBe(6);
-
-      expect(gamePlayers.find(p => p.playerId === '6').teamId)
-        .not
-        .toEqual(gamePlayers.find(p => p.playerId === '10').teamId);
+        it('should pick teams', () => {
+          expect(pickTeams(playerIds, overrides)).toEqual([
+            { playerId: 'a', gameClass: 'soldier', skill: 1, team: 'blu' },
+            { playerId: 'd', gameClass: 'soldier', skill: 4, team: 'blu' },
+            { playerId: 'b', gameClass: 'soldier', skill: 2, team: 'red' },
+            { playerId: 'c', gameClass: 'soldier', skill: 3, team: 'red' },
+          ]);
+        });
+      });
     });
   });
 
-  describe('with team overrides', () => {
-    it('should pick teams for 4 slots with friends', () => {
-      const players: PlayerSlot[] = [
-        { playerId: '0', gameClass: 'soldier', skill: 1 },
-        { playerId: '1', gameClass: 'soldier', skill: 2 },
-        { playerId: '2', gameClass: 'soldier', skill: 3 },
-        { playerId: '3', gameClass: 'soldier', skill: 4 },
-      ];
-      const gameClasses = ['soldier'];
+  describe('for 6v6', () => {
+    const playerIds: PlayerSlot[] = [
+      { playerId: 'a', gameClass: 'scout', skill: 3 },
+      { playerId: 'b', gameClass: 'scout', skill: 2 },
+      { playerId: 'c', gameClass: 'scout', skill: 2 },
+      { playerId: 'd', gameClass: 'scout', skill: 2 },
+      { playerId: 'e', gameClass: 'soldier', skill: 4 },
+      { playerId: 'f', gameClass: 'soldier', skill: 4 },
+      { playerId: 'g', gameClass: 'soldier', skill: 5 },
+      { playerId: 'h', gameClass: 'soldier', skill: 4 },
+      { playerId: 'i', gameClass: 'demoman', skill: 1 },
+      { playerId: 'j', gameClass: 'demoman', skill: 3 },
+      { playerId: 'k', gameClass: 'medic', skill: 2 },
+      { playerId: 'l', gameClass: 'medic', skill: 4 },
+    ];
+
+    it('should pick teams', () => {
+      expect(pickTeams(playerIds)).toEqual([
+        { playerId: 'a', gameClass: 'scout', skill: 3, team: 'blu' },
+        { playerId: 'b', gameClass: 'scout', skill: 2, team: 'blu' },
+        { playerId: 'e', gameClass: 'soldier', skill: 4, team: 'blu' },
+        { playerId: 'f', gameClass: 'soldier', skill: 4, team: 'blu' },
+        { playerId: 'i', gameClass: 'demoman', skill: 1, team: 'blu' },
+        { playerId: 'l', gameClass: 'medic', skill: 4, team: 'blu' },
+        { playerId: 'c', gameClass: 'scout', skill: 2, team: 'red' },
+        { playerId: 'd', gameClass: 'scout', skill: 2, team: 'red' },
+        { playerId: 'g', gameClass: 'soldier', skill: 5, team: 'red' },
+        { playerId: 'h', gameClass: 'soldier', skill: 4, team: 'red' },
+        { playerId: 'j', gameClass: 'demoman', skill: 3, team: 'red' },
+        { playerId: 'k', gameClass: 'medic', skill: 2, team: 'red' },
+      ]);
+    });
+
+    describe('with friends', () => {
       const overrides: TeamOverrides = {
         friends: [
-          [ '0', '2' ],
+          [ 'k', 'i' ],
+          [ 'l', 'g' ],
         ],
       };
 
-      const gamePlayers = pickTeams(players, gameClasses, overrides);
-      expect(gamePlayers.length).toBe(4);
-      expect(gamePlayers.find(p => p.playerId === '0').teamId)
-        .toEqual(gamePlayers.find(p => p.playerId === '2').teamId);
+      it('should pick teams', () => {
+        expect(pickTeams(playerIds, overrides)).toEqual([
+          { playerId: 'a', gameClass: 'scout', skill: 3, team: 'blu' },
+          { playerId: 'b', gameClass: 'scout', skill: 2, team: 'blu' },
+          { playerId: 'e', gameClass: 'soldier', skill: 4, team: 'blu' },
+          { playerId: 'f', gameClass: 'soldier', skill: 4, team: 'blu' },
+          { playerId: 'i', gameClass: 'demoman', skill: 1, team: 'blu' },
+          { playerId: 'k', gameClass: 'medic', skill: 2, team: 'blu' },
+
+          { playerId: 'c', gameClass: 'scout', skill: 2, team: 'red' },
+          { playerId: 'd', gameClass: 'scout', skill: 2, team: 'red' },
+          { playerId: 'g', gameClass: 'soldier', skill: 5, team: 'red' },
+          { playerId: 'h', gameClass: 'soldier', skill: 4, team: 'red' },
+          { playerId: 'j', gameClass: 'demoman', skill: 3, team: 'red' },
+          { playerId: 'l', gameClass: 'medic', skill: 4, team: 'red' },
+        ]);
+      });
     });
+  });
 
-    it('should pick teams for 12 slots with friends', () => {
-      const players: PlayerSlot[] = [
-        { playerId: '0', gameClass: 'scout', skill: 1 },
-        { playerId: '1', gameClass: 'scout', skill: 1 },
-        { playerId: '2', gameClass: 'scout', skill: 1 },
-        { playerId: '3', gameClass: 'scout', skill: 1 },
-        { playerId: '4', gameClass: 'soldier', skill: 1 },
-        { playerId: '5', gameClass: 'soldier', skill: 1 },
-        { playerId: '6', gameClass: 'soldier', skill: 5 },
-        { playerId: '7', gameClass: 'soldier', skill: 1 },
-        { playerId: '8', gameClass: 'demoman', skill: 1 },
-        { playerId: '9', gameClass: 'demoman', skill: 1 },
-        { playerId: '10', gameClass: 'medic', skill: 3 },
-        { playerId: '11', gameClass: 'medic', skill: 1 },
-      ];
-      const gameClasses = ['scout', 'soldier', 'demoman', 'medic'];
-      const overrides: TeamOverrides = {
-        friends: [
-          [ '10', '6' ],
-        ],
-      };
-      const gamePlayers = pickTeams(players, gameClasses, overrides);
+  describe('for 9v9', () => {
+    const playerIds: PlayerSlot[] = [
+      { playerId: 'a', gameClass: 'scout', skill: 1 },
+      { playerId: 'b', gameClass: 'scout', skill: 9 },
+      { playerId: 'c', gameClass: 'soldier', skill: 2 },
+      { playerId: 'd', gameClass: 'soldier', skill: 8 },
+      { playerId: 'e', gameClass: 'pyro', skill: 3 },
+      { playerId: 'f', gameClass: 'pyro', skill: 7 },
+      { playerId: 'g', gameClass: 'demoman', skill: 4 },
+      { playerId: 'h', gameClass: 'demoman', skill: 6 },
+      { playerId: 'i', gameClass: 'heavy', skill: 5 },
+      { playerId: 'j', gameClass: 'heavy', skill: 5 },
+      { playerId: 'k', gameClass: 'engineer', skill: 6 },
+      { playerId: 'l', gameClass: 'engineer', skill: 4 },
+      { playerId: 'm', gameClass: 'medic', skill: 7 },
+      { playerId: 'n', gameClass: 'medic', skill: 3 },
+      { playerId: 'o', gameClass: 'sniper', skill: 8 },
+      { playerId: 'p', gameClass: 'sniper', skill: 2 },
+      { playerId: 'q', gameClass: 'spy', skill: 9 },
+      { playerId: 'r', gameClass: 'spy', skill: 1 },
+    ];
 
-      expect(gamePlayers.find(p => p.playerId === '10').teamId)
-        .toEqual(gamePlayers.find(p => p.playerId === '6').teamId);
+    it('should pick teams', () => {
+      expect(pickTeams(playerIds)).toEqual([
+        { playerId: 'a', gameClass: 'scout', skill: 1, team: 'blu' },
+        { playerId: 'c', gameClass: 'soldier', skill: 2, team: 'blu' },
+        { playerId: 'e', gameClass: 'pyro', skill: 3, team: 'blu' },
+        { playerId: 'g', gameClass: 'demoman', skill: 4, team: 'blu' },
+        { playerId: 'i', gameClass: 'heavy', skill: 5, team: 'blu' },
+        { playerId: 'k', gameClass: 'engineer', skill: 6, team: 'blu' },
+        { playerId: 'm', gameClass: 'medic', skill: 7, team: 'blu' },
+        { playerId: 'o', gameClass: 'sniper', skill: 8, team: 'blu' },
+        { playerId: 'q', gameClass: 'spy', skill: 9, team: 'blu' },
+        { playerId: 'b', gameClass: 'scout', skill: 9, team: 'red' },
+        { playerId: 'd', gameClass: 'soldier', skill: 8, team: 'red' },
+        { playerId: 'f', gameClass: 'pyro', skill: 7, team: 'red' },
+        { playerId: 'h', gameClass: 'demoman', skill: 6, team: 'red' },
+        { playerId: 'j', gameClass: 'heavy', skill: 5, team: 'red' },
+        { playerId: 'l', gameClass: 'engineer', skill: 4, team: 'red' },
+        { playerId: 'n', gameClass: 'medic', skill: 3, team: 'red' },
+        { playerId: 'p', gameClass: 'sniper', skill: 2, team: 'red' },
+        { playerId: 'r', gameClass: 'spy', skill: 1, team: 'red' },
+      ]);
     });
+  });
 
-    it('should pick teams for 12 slots with friend pairs', () => {
-      const players: PlayerSlot[] = [
-        { playerId: '0', gameClass: 'scout', skill: 1 },
-        { playerId: '1', gameClass: 'scout', skill: 1 },
-        { playerId: '2', gameClass: 'scout', skill: 1 },
-        { playerId: '3', gameClass: 'scout', skill: 1 },
-        { playerId: '4', gameClass: 'soldier', skill: 1 },
-        { playerId: '5', gameClass: 'soldier', skill: 1 },
-        { playerId: '6', gameClass: 'soldier', skill: 5 },
-        { playerId: '7', gameClass: 'soldier', skill: 1 },
-        { playerId: '8', gameClass: 'demoman', skill: 1 },
-        { playerId: '9', gameClass: 'demoman', skill: 1 },
-        { playerId: '10', gameClass: 'medic', skill: 3 },
-        { playerId: '11', gameClass: 'medic', skill: 1 },
-      ];
-      const gameClasses = ['scout', 'soldier', 'demoman', 'medic'];
-      const overrides: TeamOverrides = {
-        friends: [
-          [ '10', '6' ],
-          [ '11', '0' ],
-        ],
-      };
-      const gamePlayers = pickTeams(players, gameClasses, overrides);
+  it('should throw an error if trying to make teams of 3 playerIds the same class', () => {
+    const playerIds: PlayerSlot[] = [
+      { playerId: 'a', gameClass: 'soldier', skill: 1 },
+      { playerId: 'b', gameClass: 'soldier', skill: 2 },
+      { playerId: 'c', gameClass: 'soldier', skill: 3 },
+      { playerId: 'd', gameClass: 'soldier', skill: 4 },
+      { playerId: 'e', gameClass: 'soldier', skill: 5 },
+      { playerId: 'f', gameClass: 'soldier', skill: 6 },
+    ];
 
-      expect(gamePlayers.find(p => p.playerId === '10').teamId)
-        .toEqual(gamePlayers.find(p => p.playerId === '6').teamId);
-      expect(gamePlayers.find(p => p.playerId === '11').teamId)
-        .toEqual(gamePlayers.find(p => p.playerId === '0').teamId);
-    });
+    expect(() => pickTeams(playerIds)).toThrow();
+  });
+
+  it('should throw an error if playerId count is not even', () => {
+    const playerIds: PlayerSlot[] = [
+      { playerId: 'a', gameClass: 'soldier', skill: 1 },
+      { playerId: 'b', gameClass: 'soldier', skill: 2 },
+      { playerId: 'c', gameClass: 'soldier', skill: 3 },
+    ];
+
+    expect(() => pickTeams(playerIds)).toThrow();
   });
 });

--- a/src/games/utils/pick-teams.ts
+++ b/src/games/utils/pick-teams.ts
@@ -1,4 +1,7 @@
-import { GamePlayer } from '../models/game-player';
+import { strict } from 'assert';
+import { NotImplementedException } from '@nestjs/common';
+import { Tf2Team } from '../models/tf2-team';
+import { meanBy } from 'lodash';
 
 export interface PlayerSlot {
   playerId: string;
@@ -6,123 +9,154 @@ export interface PlayerSlot {
   skill: number; // the skill for the given gameClass
 }
 
+export interface PlayerSlotWithTeam extends PlayerSlot {
+  team: Tf2Team;
+}
+
 export interface TeamOverrides {
   friends: string[][];
 }
 
-interface InterimTeamSetup {
-  [teamId: number]: PlayerSlot[];
-  skillDifference: number;
+interface TeamLineup {
+  lineup: PlayerSlot[];
 }
 
-function filterTeamOverrides(teamSetups: InterimTeamSetup[], overrides: TeamOverrides): InterimTeamSetup[] {
-  return teamSetups.filter(setup => {
-    return overrides.friends.every(friendPair => {
-      return (friendPair.every(f => !!setup[0].find(s => s.playerId === f)) || friendPair.every(f => !!setup[1].find(s => s.playerId === f)));
-    });
-  });
+type TeamId = 0 | 1;
+type PossibleLineup = Record<TeamId, TeamLineup>;
+
+/**
+ * Make all possible team setups.
+ * For 6v6 format, this outputs maximum of 36 combinations (3 * 3 * 2 * 2).
+ * For 9v9, it makes 512 teams (2 ^ 9).
+ * @return gameClass <=> lineup pairs.
+ */
+function makeAllPossibleLineups(gameClasses: string[], players: PlayerSlot[]): PossibleLineup[] {
+  // First off, let's make all possible lineups for each class.
+  // i.e. for scouts (A, B, C, D) make the following:
+  // ([A, B], [C, D]), ([A, C], [B, D]), ([A, D], [B, C])
+  // for medics (A, B) make only two combinatons:
+  // ([A, B]) and ([B, A])
+  const gameClassLineups = new Map<string, PossibleLineup[]>();
+  for (const gameClass of gameClasses) {
+    const playersOfGameClass = players.filter(p => p.gameClass === gameClass);
+    strict(playersOfGameClass.length % 2 === 0);
+
+    if (playersOfGameClass.length === 2) {
+      gameClassLineups.set(gameClass, [
+        {
+          0: { lineup: [ playersOfGameClass[0] ] },
+          1: { lineup: [ playersOfGameClass[1] ] },
+        },
+        {
+          0: { lineup: [ playersOfGameClass[1] ] },
+          1: { lineup: [ playersOfGameClass[0] ] },
+        },
+      ]);
+    } else if (playersOfGameClass.length === 4) {
+      gameClassLineups.set(gameClass, [
+        {
+          0: { lineup: [ playersOfGameClass[0], playersOfGameClass[1] ] },
+          1: { lineup: [ playersOfGameClass[2], playersOfGameClass[3] ] },
+        },
+        {
+          0: { lineup: [ playersOfGameClass[0], playersOfGameClass[2] ] },
+          1: { lineup: [ playersOfGameClass[1], playersOfGameClass[3] ] },
+        },
+        {
+          0: { lineup: [ playersOfGameClass[0], playersOfGameClass[3] ] },
+          1: { lineup: [ playersOfGameClass[1], playersOfGameClass[2] ] },
+        },
+      ]);
+    } else {
+      throw new NotImplementedException('more than two players of one class in a team is not implemented');
+    }
+  }
+
+  // The next thing to do is to make all combinations of the game class lineup possibilities above.
+  const possibleLineups: PossibleLineup[] = [];
+
+  function makeLineup(prev: PossibleLineup = { 0: { lineup: [] }, 1: { lineup: [] } }, i = 0) {
+    if (i === gameClasses.length) {
+      possibleLineups.push(prev);
+    } else {
+      const gameClass = gameClasses[i];
+      const gcLineups = gameClassLineups.get(gameClass);
+      for (const lineup of gcLineups) {
+        const tmp: PossibleLineup = {
+          0: { lineup: [ ...prev[0].lineup, ...lineup[0].lineup ] },
+          1: { lineup: [ ...prev[1].lineup, ...lineup[1].lineup ] },
+        }
+        makeLineup(tmp, i + 1);
+      }
+    }
+  }
+
+  makeLineup();
+  return possibleLineups;
+}
+
+interface TeamLineupWithSkillAverage extends TeamLineup {
+  skillAverage: number;
+}
+
+function calculateAverageSkill(lineup: TeamLineup): TeamLineupWithSkillAverage {
+  return { ...lineup, skillAverage: meanBy(lineup.lineup, 'skill') };
+}
+
+interface LineupWithSkillAverageDifference extends PossibleLineup {
+  skillAverageDifference: number;
+}
+
+function calculateAverageSkillDifference(lineup: Record<TeamId, TeamLineupWithSkillAverage>): LineupWithSkillAverageDifference {
+  return { ...lineup, skillAverageDifference: Math.abs(lineup[0].skillAverage - lineup[1].skillAverage) };
+}
+
+function respectsOverrides(lineup: Record<TeamId, TeamLineup>, overrides?: TeamOverrides): boolean {
+  if (overrides === undefined) {
+    return true;
+  }
+
+  function findPlayersTeam(player: string): TeamId | null {
+    if (lineup[0].lineup.find(p => p.playerId === player)) {
+      return 0;
+    } else if (lineup[1].lineup.find(p => p.playerId === player)) {
+      return 1;
+    } else {
+      return null;
+    }
+  }
+
+  return overrides.friends
+    .every(friendPair => [ ...new Set(
+      friendPair
+        .map(friend => findPlayersTeam(friend))
+        .filter(teamId => teamId !== null)
+      ) ].length < 2
+    );
 }
 
 /**
  * From the given pool of players make two teams that make the smallest average skill difference.
  */
-export function pickTeams(players: PlayerSlot[], gameClasses: string[], overrides?: TeamOverrides): GamePlayer[] {
-  const allPossibilities: {
-    gameClass: string,
-    allClassCombinations: { [teamId: number]: PlayerSlot[] }[],
-  }[] = [];
+export function pickTeams(players: PlayerSlot[], overrides?: TeamOverrides): PlayerSlotWithTeam[] {
+  const teams: Record<TeamId, Tf2Team> = { 0: Tf2Team.Blu, 1: Tf2Team.Red };
+  const gameClasses = [ ...new Set(players.map(p => p.gameClass)) ];
 
-  for (const gameClass of gameClasses) {
-    const ofGameClass = players.filter(p => p.gameClass === gameClass);
-    const allClassCombinations: { [teamId: number]: PlayerSlot[] }[] = [];
-
-    if (ofGameClass.length === 2) {
-      allClassCombinations.push({
-        0: [ ofGameClass[0] ],
-        1: [ ofGameClass[1] ],
-      });
-
-      allClassCombinations.push({
-        0: [ ofGameClass[1] ],
-        1: [ ofGameClass[0] ],
-      });
-    } else {
-      for (let i = 0; i < ofGameClass.length - 1; ++i) {
-        for (let j = i + 1; j < ofGameClass.length; ++j) {
-          const a = [];
-          const b = [];
-          for (let k = 0; k < ofGameClass.length; ++k) {
-            if (k === i || k === j) {
-              a.push(ofGameClass[k]);
-            } else {
-              b.push(ofGameClass[k]);
-            }
-          }
-
-          allClassCombinations.push({
-            0: a,
-            1: b,
-          });
-        }
-      }
-    }
-
-    allPossibilities.push({ gameClass, allClassCombinations });
-  }
-
-  const tmp = [];
-
-  function makeAllCombinations(prev: any[]) {
-    if (prev.length === gameClasses.length) {
-      tmp.push(prev);
-    } else {
-      const gameClass = gameClasses[prev.length];
-      const allClassCombinations = allPossibilities
-        .filter(p => p.gameClass === gameClass)
-        .map(p => p.allClassCombinations)
-        [0];
-      for (const c of allClassCombinations) {
-        makeAllCombinations([...prev, c]);
-      }
-    }
-  }
-
-  makeAllCombinations([]);
-
-  let allCombinations: InterimTeamSetup[] = tmp.map(c => c.reduce((prev, curr) => {
-    prev[0] = prev[0].concat(curr[0]);
-    prev[1] = prev[1].concat(curr[1]);
-    return prev;
-  }, { 0: [], 1: [] }));
-
-  allCombinations.forEach(c => {
-    const skillRed = c[0].reduce((prev, curr) => prev + curr.skill, 0) / c[0].length;
-    const skillBlu = c[1].reduce((prev, curr) => prev + curr.skill, 0) / c[1].length;
-    c.skillDifference = Math.abs(skillRed - skillBlu);
-  });
-
-  if (overrides) {
-    const tmpCombinations = filterTeamOverrides(allCombinations, overrides);
-    if (tmpCombinations.length > 0) {
-      allCombinations = tmpCombinations;
-    }
-  }
-
-  allCombinations.sort((a, b) => a.skillDifference - b.skillDifference);
-  const lowestSkillDifference = allCombinations[0].skillDifference;
-  const possibleTeams = allCombinations.filter(c => c.skillDifference === lowestSkillDifference);
-  const selected = possibleTeams[Math.floor(Math.random() * possibleTeams.length)];
-
-  return Object.keys(selected)
-    .map(key => {
-      if (selected[key].length) {
-        return selected[key].map(p => ({...p, teamId: key}));
-      }
+  const allPossibleLineups = makeAllPossibleLineups(gameClasses, players)
+    .filter(lineup => respectsOverrides(lineup, overrides))
+    .map(lineup => {
+      return {
+        0: calculateAverageSkill(lineup[0]),
+        1: calculateAverageSkill(lineup[1]),
+      };
     })
-    .filter(e => !!e)
-    .flatMap(p => p)
-    .map(p => {
-      const { skill, ...player } = p;
-      return { ...player, status: 'active' };
-    });
+    .map(lineup => calculateAverageSkillDifference(lineup))
+    .sort((a, b) => a.skillAverageDifference - b.skillAverageDifference);
+
+  const selectedLineup = allPossibleLineups[0];
+
+  return [0, 1]
+    .flatMap(teamId => (selectedLineup[teamId] as TeamLineup).lineup
+      .map(slot => ({ ...slot, team: teams[teamId] }))
+    );
 }

--- a/src/games/utils/rcon-commands.ts
+++ b/src/games/utils/rcon-commands.ts
@@ -1,8 +1,8 @@
-export function addGamePlayer(steamId: string, name: string, teamId: number, gameClass: string) {
+export function addGamePlayer(steamId: string, name: string, team: string, gameClass: string) {
   return [
     `sm_game_player_add ${steamId}`,
     `-name "${name}"`,
-    `-team ${teamId}`,
+    `-team ${team}`,
     `-class ${gameClass}`,
   ].join(' ');
 }

--- a/src/queue/services/queue-announcements.service.spec.ts
+++ b/src/queue/services/queue-announcements.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { QueueAnnouncementsService } from './queue-announcements.service';
 import { GamesService } from '@/games/services/games.service';
+import { Tf2Team } from '@/games/models/tf2-team';
 
 class GamesServiceStub {
   getGamesWithSubstitutionRequests() {
@@ -8,16 +9,15 @@ class GamesServiceStub {
       {
         id: 'FAKE_GAME_ID',
         number: 234,
-        teams: new Map([[1, 'RED'], [2, 'BLU']]),
         slots: [
           {
             gameClass: 'soldier',
-            teamId: 1,
+            team: Tf2Team.Blu,
             status: 'waiting for substitute',
           },
           {
             gameClass: 'soldier',
-            teamId: 2,
+            team: Tf2Team.Red,
             status: 'active',
           },
         ],
@@ -52,7 +52,7 @@ describe('QueueAnnouncementsService', () => {
           gameId: 'FAKE_GAME_ID',
           gameNumber: 234,
           gameClass: 'soldier',
-          team: 'RED',
+          team: 'BLU',
         },
       ]);
     });

--- a/src/queue/services/queue-announcements.service.ts
+++ b/src/queue/services/queue-announcements.service.ts
@@ -21,7 +21,7 @@ export class QueueAnnouncementsService {
           gameId: game.id,
           gameNumber: game.number,
           gameClass: slot.gameClass,
-          team: game.teams.get(slot.teamId),
+          team: slot.team.toUpperCase(),
         };
       });
     });


### PR DESCRIPTION
Use 'blu' and 'red' to identify teams in the `GameModel`.

BREAKING CHANGE: Game.teams is now gone, `GamePlayer.teamId` is moved to `GamePlayer.team`.
