### PR TITLE
refactor!: get rid of Game.players

### DIFF
--- a/migrations/1592135286326-rename-gameplayer-player-id-to-player.js
+++ b/migrations/1592135286326-rename-gameplayer-player-id-to-player.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const mongodb = require('mongodb');
+require('dotenv').config();
+
+let credentials = '';
+if (process.env.MONGODB_USERNAME) {
+  if (process.env.MONGODB_PASSWORD) {
+    credentials = `${process.env.MONGODB_USERNAME}:${process.env.MONGODB_PASSWORD}@`;
+  } else {
+    credentials = `${process.env.MONGODB_USERNAME}@`;
+  }
+}
+
+const uri = `mongodb://${credentials}${process.env.MONGODB_HOST}:${process.env.MONGODB_PORT}/${process.env.MONGODB_DB}`;
+
+module.exports.up = function (next) {
+  mongodb.MongoClient.connect(uri, { useUnifiedTopology: true })
+    .then(client => client.db())
+    .then(db => {
+      const Games = db.collection('games');
+      return Games.find().forEach(game => {
+        game.slots.forEach(slot => {
+          if (!slot.player) {
+            slot.player = slot.playerId;
+          }
+        });
+
+        return Games.save(game);
+      });
+    })
+    .then(next);
+}
+
+module.exports.down = function (next) {
+  next()
+}

--- a/src/documents/controllers/documents.controller.spec.ts
+++ b/src/documents/controllers/documents.controller.spec.ts
@@ -35,7 +35,7 @@ describe('Documents Controller', () => {
       expect(ret).toEqual('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris in.');
     });
 
-    describe('when the document could not be found', async () => {
+    describe('when the document could not be found', () => {
       beforeEach(() => {
         jest.spyOn(documentsService, 'fetchDocument').mockResolvedValue(undefined);
       });

--- a/src/games/controllers/games.controller.spec.ts
+++ b/src/games/controllers/games.controller.spec.ts
@@ -7,8 +7,8 @@ import { PlayerSubstitutionService } from '../services/player-substitution.servi
 
 class GamesServiceStub {
   games: Game[] = [
-    { number: 1, map: 'cp_fake_rc1', state: 'ended', assignedSkills: new Map([['FAKE_PLAYER_ID', 1]]) },
-    { number: 2, map: 'cp_fake_rc2', state: 'launching', assignedSkills: new Map([['FAKE_PLAYER_ID', 5]]) },
+    { number: 1, map: 'cp_fake_rc1', state: 'ended', assignedSkills: new Map([['FAKE_PLAYER_ID', 1]]) } as Game,
+    { number: 2, map: 'cp_fake_rc2', state: 'launching', assignedSkills: new Map([['FAKE_PLAYER_ID', 5]]) } as Game,
   ];
   getGames(sort: any, limit: number, skip: number) { return new Promise(resolve => resolve(this.games)); }
   getGameCount() { return new Promise(resolve => resolve(2)); }

--- a/src/games/models/game-player.ts
+++ b/src/games/models/game-player.ts
@@ -8,7 +8,7 @@ import { Player } from '@/players/models/player';
 export class GamePlayer {
 
   @prop({ required: true, ref: Player })
-  playerId!: Ref<Player>;
+  player!: Ref<Player>;
 
   @prop({ required: true, enum: Tf2Team })
   team!: Tf2Team;

--- a/src/games/models/game-player.ts
+++ b/src/games/models/game-player.ts
@@ -1,13 +1,14 @@
-import { prop, index } from '@typegoose/typegoose';
+import { prop, index, Ref } from '@typegoose/typegoose';
 import { PlayerConnectionStatus } from './player-connection-status';
 import { Tf2Team } from './tf2-team';
+import { Player } from '@/players/models/player';
 
 @index({ playerId: 1 })
 @index({ status: 1 })
 export class GamePlayer {
 
-  @prop({ required: true })
-  playerId!: string;
+  @prop({ required: true, ref: Player })
+  playerId!: Ref<Player>;
 
   @prop({ required: true, enum: Tf2Team })
   team!: Tf2Team;

--- a/src/games/models/game.ts
+++ b/src/games/models/game.ts
@@ -51,7 +51,7 @@ export class Game {
 
   findPlayerSlot(playerId: string | ObjectId) {
     const _playerId = new ObjectId(playerId);
-    return this.slots.find(s => _playerId.equals(s.playerId as ObjectId));
+    return this.slots.find(s => _playerId.equals(s.player as ObjectId));
   }
 
 }

--- a/src/games/models/game.ts
+++ b/src/games/models/game.ts
@@ -1,7 +1,7 @@
-import { prop, mapProp, arrayProp, Ref, index } from '@typegoose/typegoose';
-import { Player } from '@/players/models/player';
+import { prop, Ref, index } from '@typegoose/typegoose';
 import { GamePlayer } from './game-player';
 import { GameServer } from '@/game-servers/models/game-server';
+import { ObjectId } from 'mongodb';
 
 type GameState = 'launching' | 'started' | 'ended' | 'interrupted';
 
@@ -16,13 +16,10 @@ export class Game {
   @prop({ required: true, unique: true })
   number!: number;
 
-  @arrayProp({ ref: 'Player' })
-  players?: Ref<Player>[];
+  @prop({ items: GamePlayer, required: true })
+  slots!: GamePlayer[];
 
-  @arrayProp({ items: GamePlayer })
-  slots?: GamePlayer[];
-
-  @mapProp({ of: Number })
+  @prop({ of: Number })
   assignedSkills?: Map<string, number>;
 
   @prop({ required: true })
@@ -46,10 +43,15 @@ export class Game {
   @prop({ ref: () => GameServer })
   gameServer?: Ref<GameServer>;
 
-  @mapProp({ of: Number })
+  @prop({ of: Number })
   score?: Map<string, number>;
 
   @prop()
   stvConnectString?: string;
+
+  findPlayerSlot(playerId: string | ObjectId) {
+    const _playerId = new ObjectId(playerId);
+    return this.slots.find(s => _playerId.equals(s.playerId as ObjectId));
+  }
 
 }

--- a/src/games/models/game.ts
+++ b/src/games/models/game.ts
@@ -6,7 +6,6 @@ import { ObjectId } from 'mongodb';
 type GameState = 'launching' | 'started' | 'ended' | 'interrupted';
 
 @index({ state: 1 })
-@index({ players: 1 })
 @index({ gameServer: 1 })
 export class Game {
 

--- a/src/games/services/__mocks__/games.service.ts
+++ b/src/games/services/__mocks__/games.service.ts
@@ -31,7 +31,7 @@ export class GamesService {
       number: ++this.lastGameId,
       map: 'cp_badlands',
       slots: players.map(p => ({
-        playerId: new ObjectId(p.id),
+        player: new ObjectId(p.id),
         team: teams[`${(lastTeamId++) % 2}`],
         gameClass: 'soldier',
       })),

--- a/src/games/services/__mocks__/games.service.ts
+++ b/src/games/services/__mocks__/games.service.ts
@@ -3,6 +3,7 @@ import { InjectModel } from 'nestjs-typegoose';
 import { Game } from '@/games/models/game';
 import { ReturnModelType } from '@typegoose/typegoose';
 import { Player } from '@/players/models/player';
+import { ObjectId } from 'mongodb';
 
 @Injectable()
 export class GamesService {
@@ -30,11 +31,10 @@ export class GamesService {
       number: ++this.lastGameId,
       map: 'cp_badlands',
       slots: players.map(p => ({
-        playerId: p.id,
+        playerId: new ObjectId(p.id),
         team: teams[`${(lastTeamId++) % 2}`],
         gameClass: 'soldier',
       })),
-      players,
       state: 'launching',
     });
   }

--- a/src/games/services/game-event-handler.service.spec.ts
+++ b/src/games/services/game-event-handler.service.spec.ts
@@ -181,7 +181,7 @@ describe('GameEventHandlerService', () => {
     it('should update the player\'s online state', async () => {
       await service.onPlayerJoining(mockGame.id, player1.steamId);
       const game = await gamesService.getById(mockGame.id);
-      expect(game.slots.find(s => player1.id === s.playerId).connectionStatus).toEqual('joining');
+      expect(game.findPlayerSlot(player1.id).connectionStatus).toEqual('joining');
     });
 
     it('should emit an event over ws', async () => {
@@ -195,7 +195,7 @@ describe('GameEventHandlerService', () => {
     it('should update the player\'s online state', async () => {
       await service.onPlayerConnected(mockGame.id, player1.steamId);
       const game = await gamesService.getById(mockGame.id);
-      expect(game.slots.find(s => player1._id.equals(s.playerId)).connectionStatus).toEqual('connected');
+      expect(game.findPlayerSlot(player1.id).connectionStatus).toEqual('connected');
     });
 
     it('should emit an event over ws', async () => {
@@ -209,7 +209,7 @@ describe('GameEventHandlerService', () => {
     it('should update the player\'s online state', async () => {
       await service.onPlayerDisconnected(mockGame.id, player1.steamId);
       const game = await gamesService.getById(mockGame.id);
-      expect(game.slots.find(s => player1._id.equals(s.playerId)).connectionStatus).toEqual('offline');
+      expect(game.findPlayerSlot(player1.id).connectionStatus).toEqual('offline');
     });
 
     it('should emit an event over ws', async () => {

--- a/src/games/services/game-event-handler.service.ts
+++ b/src/games/services/game-event-handler.service.ts
@@ -92,7 +92,7 @@ export class GameEventHandlerService {
 
     const game = await this.gamesService.getById(gameId);
     if (game) {
-      const slot = game.slots.find(s => s.playerId === player.id);
+      const slot = game.findPlayerSlot(player.id);
       if (slot) {
         slot.connectionStatus = connectionStatus;
         await game.save();

--- a/src/games/services/game-runtime.service.spec.ts
+++ b/src/games/services/game-runtime.service.spec.ts
@@ -220,7 +220,7 @@ describe('GameRuntimeService', () => {
       it('should close the RCON connection', async () => {
         const spy = jest.spyOn(rcon, 'end');
         await service.replacePlayer(mockGame.id, mockPlayers[0].id, {
-          playerId: new ObjectId().toHexString(),
+          player: new ObjectId(),
           team: Tf2Team.Red,
           gameClass: 'soldier',
         });
@@ -231,7 +231,7 @@ describe('GameRuntimeService', () => {
     it('should close the RCON connection', async () => {
       const spy = jest.spyOn(rcon, 'end');
       await service.replacePlayer(mockGame.id, mockPlayers[0].id, {
-        playerId: new ObjectId().toHexString(),
+        player: new ObjectId(),
         team: Tf2Team.Red,
         gameClass: 'soldier',
       });

--- a/src/games/services/game-runtime.service.ts
+++ b/src/games/services/game-runtime.service.ts
@@ -88,7 +88,7 @@ export class GameRuntimeService {
 
     try {
       rcon = await this.rconFactoryService.createRcon(gameServer);
-      const player = isRefType(replacementSlot.playerId) ? await this.playersService.getById(replacementSlot.playerId) : replacementSlot.playerId;
+      const player = isRefType(replacementSlot.player) ? await this.playersService.getById(replacementSlot.player) : replacementSlot.player;
 
       const cmd = addGamePlayer(player.steamId, player.name, replacementSlot.team, replacementSlot.gameClass);
       this.logger.debug(cmd);

--- a/src/games/services/game-runtime.service.ts
+++ b/src/games/services/game-runtime.service.ts
@@ -8,6 +8,7 @@ import { addGamePlayer, delGamePlayer, say } from '../utils/rcon-commands';
 import { GamePlayer } from '../models/game-player';
 import { GamesGateway } from '../gateways/games.gateway';
 import { Rcon } from 'rcon-client/lib';
+import { isRefType } from '@typegoose/typegoose';
 
 @Injectable()
 export class GameRuntimeService {
@@ -87,7 +88,7 @@ export class GameRuntimeService {
 
     try {
       rcon = await this.rconFactoryService.createRcon(gameServer);
-      const player = await this.playersService.getById(replacementSlot.playerId);
+      const player = isRefType(replacementSlot.playerId) ? await this.playersService.getById(replacementSlot.playerId) : replacementSlot.playerId;
 
       const cmd = addGamePlayer(player.steamId, player.name, replacementSlot.team, replacementSlot.gameClass);
       this.logger.debug(cmd);

--- a/src/games/services/games.service.spec.ts
+++ b/src/games/services/games.service.spec.ts
@@ -130,7 +130,7 @@ describe('GamesService', () => {
           state: 'started',
           slots: [
             {
-              playerId,
+              player: playerId,
               status: 'active',
               gameClass: 'soldier',
               team: Tf2Team.Blu,
@@ -158,7 +158,7 @@ describe('GamesService', () => {
           state: 'started',
           slots: [
             {
-              playerId,
+              player: playerId,
               status: 'waiting for substitute',
               gameClass: 'soldier',
               team: Tf2Team.Blu,
@@ -188,13 +188,13 @@ describe('GamesService', () => {
           state: 'started',
           slots: [
             {
-              playerId,
+              player: playerId,
               status: 'replaced',
               gameClass: 'soldier',
               team: Tf2Team.Blu,
             },
             {
-              playerId: player2Id,
+              player: player2Id,
               status: 'active',
               gameClass: 'soldier',
               team: Tf2Team.Red,
@@ -220,7 +220,7 @@ describe('GamesService', () => {
           state: 'ended',
           slots: [
             {
-              playerId,
+              player: playerId,
               status: 'active',
               gameClass: 'soldier',
               team: Tf2Team.Blu,
@@ -312,13 +312,13 @@ describe('GamesService', () => {
         number: 1,
         slots: [
           {
-            playerId: player1,
+            player: player1,
             team: Tf2Team.Blu,
             gameClass: 'scout',
             status: 'waiting for substitute',
           },
           {
-            playerId: player2,
+            player: player2,
             team: Tf2Team.Red,
             gameClass: 'scout',
             status: 'active',

--- a/src/games/services/games.service.spec.ts
+++ b/src/games/services/games.service.spec.ts
@@ -90,7 +90,7 @@ describe('GamesService', () => {
     let game: DocumentType<Game>;
 
     beforeEach(async () => {
-      game = await gameModel.create({ number: 1, map: 'cp_badlands', state: 'launching' });
+      game = await gameModel.create({ number: 1, map: 'cp_badlands', state: 'launching', slots: [] });
     });
 
     it('should get the game by its id', async () => {
@@ -105,9 +105,9 @@ describe('GamesService', () => {
     let endedGame: DocumentType<Game>;
 
     beforeEach(async () => {
-      launchingGame = await gameModel.create({ number: 1, map: 'cp_badlands', state: 'launching' });
-      runningGame = await gameModel.create({ number: 2, map: 'cp_badlands', state: 'started' });
-      endedGame = await gameModel.create({ number: 3, map: 'cp_badlands', state: 'ended' });
+      launchingGame = await gameModel.create({ number: 1, map: 'cp_badlands', state: 'launching', slots: [] });
+      runningGame = await gameModel.create({ number: 2, map: 'cp_badlands', state: 'started', slots: [] });
+      endedGame = await gameModel.create({ number: 3, map: 'cp_badlands', state: 'ended', slots: [] });
     });
 
     it('should get only running games', async () => {
@@ -128,10 +128,9 @@ describe('GamesService', () => {
           number: 1,
           map: 'cp_badlands',
           state: 'started',
-          players: [ playerId ],
           slots: [
             {
-              playerId: playerId.toString(),
+              playerId,
               status: 'active',
               gameClass: 'soldier',
               team: Tf2Team.Blu,
@@ -147,7 +146,7 @@ describe('GamesService', () => {
       });
     });
 
-    describe('when a player is marked as awaitng substitute in a gem', () => {
+    describe('when a player is marked as awaitng substitute in a game', () => {
       let game: DocumentType<Game>;
       let playerId: ObjectId;
 
@@ -157,10 +156,9 @@ describe('GamesService', () => {
           number: 1,
           map: 'cp_badlands',
           state: 'started',
-          players: [ playerId ],
           slots: [
             {
-              playerId: playerId.toString(),
+              playerId,
               status: 'waiting for substitute',
               gameClass: 'soldier',
               team: Tf2Team.Blu,
@@ -188,16 +186,15 @@ describe('GamesService', () => {
           number: 1,
           map: 'cp_badlands',
           state: 'started',
-          players: [ playerId ],
           slots: [
             {
-              playerId: playerId.toString(),
+              playerId,
               status: 'replaced',
               gameClass: 'soldier',
               team: Tf2Team.Blu,
             },
             {
-              playerId: player2Id.toString(),
+              playerId: player2Id,
               status: 'active',
               gameClass: 'soldier',
               team: Tf2Team.Red,
@@ -221,10 +218,9 @@ describe('GamesService', () => {
           number: 1,
           map: 'cp_badlands',
           state: 'ended',
-          players: [ playerId ],
           slots: [
             {
-              playerId: playerId.toString(),
+              playerId,
               status: 'active',
               gameClass: 'soldier',
               team: Tf2Team.Blu,
@@ -288,7 +284,6 @@ describe('GamesService', () => {
         number: 1,
         map: 'cp_fake',
         slots: expect.any(Array),
-        players: slots.map(s => s.playerId),
         assignedSkills: expect.any(Object),
         state: 'launching',
         launchedAt: expect.any(Date),
@@ -315,16 +310,15 @@ describe('GamesService', () => {
 
       game = await gameModel.create({
         number: 1,
-        players: [ player1, player2 ],
         slots: [
           {
-            playerId: player1.toString(),
+            playerId: player1,
             team: Tf2Team.Blu,
             gameClass: 'scout',
             status: 'waiting for substitute',
           },
           {
-            playerId: player2.toString(),
+            playerId: player2,
             team: Tf2Team.Red,
             gameClass: 'scout',
             status: 'active',
@@ -350,7 +344,6 @@ describe('GamesService', () => {
 
       await gameModel.create({
         number: 1,
-        players: [ player ],
         slots: [],
         map: 'cp_badlands',
         state: 'launching',
@@ -359,7 +352,6 @@ describe('GamesService', () => {
       const gameServer = new ObjectId();
       await gameModel.create({
         number: 2,
-        players: [ player ],
         slots: [],
         map: 'cp_badlands',
         state: 'launching',

--- a/src/games/services/games.service.ts
+++ b/src/games/services/games.service.ts
@@ -10,7 +10,6 @@ import { QueueConfigService } from '@/queue/services/queue-config.service';
 import { GameLauncherService } from './game-launcher.service';
 import { GamesGateway } from '../gateways/games.gateway';
 import { ObjectId } from 'mongodb';
-import { FilterQuery } from 'mongoose';
 import { shuffle } from 'lodash';
 
 interface GameSortOptions {
@@ -57,7 +56,7 @@ export class GamesService {
 
   async getPlayerGames(playerId: string, sort: GameSortOptions = { launchedAt: -1 }, limit: number = 10, skip: number = 0) {
     return await this.gameModel
-      .find({ players: new ObjectId(playerId) })
+      .find({ 'slots.playerId': new ObjectId(playerId) })
       .sort(sort)
       .limit(limit)
       .skip(skip);
@@ -67,7 +66,7 @@ export class GamesService {
     const defaultOptions: GetPlayerGameCountOptions = { endedOnly: false };
     const _options = { ...defaultOptions, ...options };
 
-    let criteria: any = { players: playerId };
+    let criteria: any = { 'slots.playerId': playerId };
     if (_options.endedOnly) {
       criteria = { ...criteria, state: 'ended' };
     }
@@ -77,12 +76,12 @@ export class GamesService {
 
   async getPlayerPlayedClassCount(playerId: string): Promise<{ [gameClass: string]: number }> {
     // fixme refactor this to aggregate
-    const allGames = await this.gameModel.find({ players: new ObjectId(playerId), state: 'ended' });
+    const allGames = await this.gameModel.find({ 'slots.playerId': new ObjectId(playerId), state: 'ended' });
     return this.queueConfigService.queueConfig.classes
       .map(cls => cls.name)
       .reduce((prev, gameClass) => {
         prev[gameClass] = allGames
-          .filter(g => !!g.slots.find(s => s.playerId === playerId && s.gameClass === gameClass))
+          .filter(g => g.findPlayerSlot(playerId)?.gameClass === gameClass)
           .length;
         return prev;
       }, {});
@@ -107,14 +106,14 @@ export class GamesService {
 
     const players: PlayerSlot[] = await Promise.all(queueSlots.map(slot => this.queueSlotToPlayerSlot(slot)));
     const assignedSkills = players.reduce((prev, curr) => { prev[curr.playerId] = curr.skill; return prev; }, { });
-    const slots = pickTeams(shuffle(players), { friends });
+    const slots = pickTeams(shuffle(players), { friends })
+      .map(s => ({ ...s, playerId: new ObjectId(s.playerId) }));
     const gameNo = await this.getNextGameNumber();
 
     const game = await this.gameModel.create({
       number: gameNo,
       map,
       slots,
-      players: queueSlots.map(s => new ObjectId(s.playerId)),
       assignedSkills,
       state: 'launching',
     });

--- a/src/games/services/games.service.ts
+++ b/src/games/services/games.service.ts
@@ -56,7 +56,7 @@ export class GamesService {
 
   async getPlayerGames(playerId: string, sort: GameSortOptions = { launchedAt: -1 }, limit: number = 10, skip: number = 0) {
     return await this.gameModel
-      .find({ 'slots.playerId': new ObjectId(playerId) })
+      .find({ 'slots.player': new ObjectId(playerId) })
       .sort(sort)
       .limit(limit)
       .skip(skip);
@@ -66,7 +66,7 @@ export class GamesService {
     const defaultOptions: GetPlayerGameCountOptions = { endedOnly: false };
     const _options = { ...defaultOptions, ...options };
 
-    let criteria: any = { 'slots.playerId': playerId };
+    let criteria: any = { 'slots.player': playerId };
     if (_options.endedOnly) {
       criteria = { ...criteria, state: 'ended' };
     }
@@ -76,7 +76,7 @@ export class GamesService {
 
   async getPlayerPlayedClassCount(playerId: string): Promise<{ [gameClass: string]: number }> {
     // fixme refactor this to aggregate
-    const allGames = await this.gameModel.find({ 'slots.playerId': new ObjectId(playerId), state: 'ended' });
+    const allGames = await this.gameModel.find({ 'slots.player': new ObjectId(playerId), state: 'ended' });
     return this.queueConfigService.queueConfig.classes
       .map(cls => cls.name)
       .reduce((prev, gameClass) => {
@@ -93,7 +93,7 @@ export class GamesService {
       slots: {
         $elemMatch: {
           status: /active|waiting for substitute/,
-          playerId,
+          player: playerId,
         },
       },
     });
@@ -107,7 +107,7 @@ export class GamesService {
     const players: PlayerSlot[] = await Promise.all(queueSlots.map(slot => this.queueSlotToPlayerSlot(slot)));
     const assignedSkills = players.reduce((prev, curr) => { prev[curr.playerId] = curr.skill; return prev; }, { });
     const slots = pickTeams(shuffle(players), { friends })
-      .map(s => ({ ...s, playerId: new ObjectId(s.playerId) }));
+      .map(s => ({ ...s, player: new ObjectId(s.playerId) }));
     const gameNo = await this.getNextGameNumber();
 
     const game = await this.gameModel.create({

--- a/src/games/services/player-substitution.service.spec.ts
+++ b/src/games/services/player-substitution.service.spec.ts
@@ -138,7 +138,7 @@ describe('PlayerSubstitutionService', () => {
     it('should update the player status', async () => {
       const game = await service.substitutePlayer(mockGame.id, player1.id);
       expect(game.id).toEqual(mockGame.id);
-      const slot = game.slots.find(s => s.playerId === player1.id);
+      const slot = game.findPlayerSlot(player1.id);
       expect(slot.status).toEqual('waiting for substitute');
     });
 
@@ -219,7 +219,7 @@ describe('PlayerSubstitutionService', () => {
 
     it('should update the player status', async () => {
       const game = await service.cancelSubstitutionRequest(mockGame.id, player1.id);
-      const slot = game.slots.find(s => s.playerId === player1.id);
+      const slot = game.findPlayerSlot(player1.id);
       expect(slot.status).toEqual('active');
     });
 
@@ -270,12 +270,11 @@ describe('PlayerSubstitutionService', () => {
       // replace player 1 with player 3
       const game = await service.replacePlayer(mockGame.id, player1.id, player3.id);
       expect(game.id).toEqual(mockGame.id);
-      const replaceeSlot = game.slots.find(s => s.playerId === player1.id);
+      const replaceeSlot = game.findPlayerSlot(player1.id);
       expect(replaceeSlot.status).toBe('replaced');
-      const replacementSlot = game.slots.find(s => s.playerId === player3.id);
+      const replacementSlot = game.findPlayerSlot(player3.id);
       expect(replacementSlot).toBeTruthy();
       expect(replacementSlot.status).toBe('active');
-      expect(game.players.find((p: ObjectId) => p.equals(player3.id))).toBeTruthy();
     });
 
     it('should emit the event', async () => {
@@ -288,7 +287,7 @@ describe('PlayerSubstitutionService', () => {
       const spy = jest.spyOn(gameRuntimeService, 'replacePlayer');
       await service.replacePlayer(mockGame.id, player1.id, player3.id);
       setTimeout(() => {
-        expect(spy).toHaveBeenCalledWith(mockGame.id, player1.id, expect.objectContaining({ playerId: player3.id }));
+        expect(spy).toHaveBeenCalledWith(mockGame.id, player1.id, expect.objectContaining({ playerId: player3._id }));
         done();
       }, 100);
     });
@@ -317,7 +316,7 @@ describe('PlayerSubstitutionService', () => {
     it('should mark the slot back as active if a player is subbing himself', async () => {
       const game = await service.replacePlayer(mockGame.id, player1.id, player1.id);
       expect(game.id).toEqual(mockGame.id);
-      const slot = game.slots.find(s => s.playerId === player1.id);
+      const slot = game.findPlayerSlot(player1.id);
       expect(slot.status).toBe('active');
       expect(game.slots.length).toBe(2);
     });

--- a/src/games/services/player-substitution.service.spec.ts
+++ b/src/games/services/player-substitution.service.spec.ts
@@ -287,7 +287,7 @@ describe('PlayerSubstitutionService', () => {
       const spy = jest.spyOn(gameRuntimeService, 'replacePlayer');
       await service.replacePlayer(mockGame.id, player1.id, player3.id);
       setTimeout(() => {
-        expect(spy).toHaveBeenCalledWith(mockGame.id, player1.id, expect.objectContaining({ playerId: player3._id }));
+        expect(spy).toHaveBeenCalledWith(mockGame.id, player1.id, expect.objectContaining({ player: player3._id }));
         done();
       }, 100);
     });

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -11,6 +11,7 @@ import { DiscordService } from '@/discord/services/discord.service';
 import { substituteRequest } from '@/discord/notifications';
 import { Environment } from '@/environment/environment';
 import { Message } from 'discord.js';
+import { ObjectId } from 'mongodb';
 
 /**
  * A service that handles player substitution logic.
@@ -137,20 +138,19 @@ export class PlayerSubstitutionService {
       throw new Error('no such player');
     }
 
-    let replacementSlot: GamePlayer = game.slots.find(s => s.playerId === replacementId);
+    let replacementSlot = game.findPlayerSlot(replacementId);
     if (replacementSlot) {
       replacementSlot.status = 'active';
     } else {
       // create new slot of the replacement player
       replacementSlot = {
-        playerId: replacementId,
+        playerId: new ObjectId(replacementId),
         team: slot.team,
         gameClass: slot.gameClass,
         status: 'active',
       };
 
       game.slots.push(replacementSlot);
-      game.players.push(replacement);
     }
 
     // update replacee
@@ -186,7 +186,7 @@ export class PlayerSubstitutionService {
       throw new Error('no such game');
     }
 
-    const slot = game.slots.find(s => s.playerId === playerId);
+    const slot = game.findPlayerSlot(playerId);
     if (!slot) {
       throw new Error('no such player');
     }

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -144,7 +144,7 @@ export class PlayerSubstitutionService {
     } else {
       // create new slot of the replacement player
       replacementSlot = {
-        playerId: new ObjectId(replacementId),
+        player: new ObjectId(replacementId),
         team: slot.team,
         gameClass: slot.gameClass,
         status: 'active',

--- a/src/games/services/server-configurator.service.spec.ts
+++ b/src/games/services/server-configurator.service.spec.ts
@@ -50,12 +50,12 @@ const game = {
   map: 'cp_badlands',
   slots: [
     {
-      playerId: 'PLAYER_1',
+      player: 'PLAYER_1',
       team: Tf2Team.Blu,
       gameClass: 'soldier',
     },
     {
-      playerId: 'PLAYER_2',
+      player: 'PLAYER_2',
       team: Tf2Team.Red,
       gameClass: 'soldier',
     },

--- a/src/games/services/server-configurator.service.ts
+++ b/src/games/services/server-configurator.service.ts
@@ -11,6 +11,7 @@ import { logAddressAdd, changelevel, execConfig, setPassword, addGamePlayer, log
 import { deburr } from 'lodash';
 import { extractConVarValue } from '../utils/extract-con-var-value';
 import { Rcon } from 'rcon-client/lib';
+import { isRefType } from '@typegoose/typegoose';
 
 @Injectable()
 export class ServerConfiguratorService {
@@ -65,7 +66,7 @@ export class ServerConfiguratorService {
       await rcon.send(setPassword(password));
 
       for (const slot of game.slots) {
-        const player = await this.playersService.getById(slot.playerId);
+        const player = isRefType(slot.player) ? await this.playersService.getById(slot.player) : slot.player;
 
         const playerName = deburr(player.name);
         const cmd = addGamePlayer(player.steamId, playerName, slot.team, slot.gameClass);

--- a/src/players/controllers/players.controller.spec.ts
+++ b/src/players/controllers/players.controller.spec.ts
@@ -35,8 +35,8 @@ class PlayersServiceStub {
 
 class GamesServiceStub {
   games: Game[] = [
-    { number: 1, map: 'cp_fake_rc1', state: 'ended' },
-    { number: 2, map: 'cp_fake_rc2', state: 'launching' },
+    { number: 1, map: 'cp_fake_rc1', state: 'ended', slots: [] } as Game,
+    { number: 2, map: 'cp_fake_rc2', state: 'launching', slots: [] } as Game,
   ];
   getPlayerGames(playerId: string, sort: any = { launchedAt: -1 }, limit: number = 10, skip: number = 0) {
     return Promise.resolve(this.games);

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -15,6 +15,7 @@ import { Subject } from 'rxjs';
 import { TwitchTvUser } from '../models/twitch-tv-user';
 import { DiscordService } from '@/discord/services/discord.service';
 import { newPlayer, playerNameChanged } from '@/discord/notifications';
+import { ObjectId } from 'mongodb';
 
 @Injectable()
 export class PlayersService {
@@ -43,7 +44,7 @@ export class PlayersService {
     return await this.playerModel.find();
   }
 
-  async getById(id: string): Promise<DocumentType<Player>> {
+  async getById(id: string | ObjectId): Promise<DocumentType<Player>> {
     return await this.playerModel.findById(id);
   }
 


### PR DESCRIPTION
* remove `Game.players` field
* rename `GamePlayer.playerId` to `GamePlayer.player`
* `GamePlayer.player` now holds reference to `Player`
* add `Game.findPlayerSlot()`

BREAKING CHANGE: `Game.players` is gone, `GamePlayer.playerId` is renamed to `GamePlayer.player`