### PR TITLE
fix(games): prevent team overrides from eliminating all possible lineups

### DIFF
--- a/src/games/utils/pick-teams.spec.ts
+++ b/src/games/utils/pick-teams.spec.ts
@@ -1,5 +1,4 @@
 import { pickTeams, PlayerSlot, TeamOverrides } from './pick-teams';
-import { shuffle } from 'lodash';
 
 describe('pickTeams', () => {
   describe('for 2v2', () => {
@@ -132,8 +131,6 @@ describe('pickTeams', () => {
         { playerId: 'loww', gameClass: 'soldier', skill: 3 },
       ];
 
-      console.log(players);
-
       const overrides: TeamOverrides = {
         friends: [
           ['bobair', 'kwq'],
@@ -141,8 +138,22 @@ describe('pickTeams', () => {
         ],
       };
 
-      it.only('should pick teams', () => {
-        expect(pickTeams(players, overrides)).toEqual([]);
+      it('should pick teams', () => {
+        expect(pickTeams(players, overrides)).toEqual([
+          { playerId: 'zinner', gameClass: 'soldier', skill: 4, team: 'blu' },
+          { playerId: 'mielzky', gameClass: 'soldier', skill: 2, team: 'blu' },
+          { playerId: 'cieniu97', gameClass: 'demoman', skill: 2, team: 'blu' },
+          { playerId: 'stan', gameClass: 'medic', skill: 4, team: 'blu' },
+          { playerId: 'graba', gameClass: 'scout', skill: 4, team: 'blu' },
+          { playerId: 'crzje', gameClass: 'scout', skill: 4, team: 'blu' },
+
+          { playerId: 'wonder', gameClass: 'soldier', skill: 3, team: 'red' },
+          { playerId: 'loww', gameClass: 'soldier', skill: 3, team: 'red' },
+          { playerId: 'mejf', gameClass: 'demoman', skill: 3, team: 'red' },
+          { playerId: 'bobair', gameClass: 'medic', skill: 1, team: 'red' },
+          { playerId: 'kwq', gameClass: 'scout', skill: 7, team: 'red' },
+          { playerId: 'antro15cm', gameClass: 'scout', skill: 2, team: 'red' },
+        ]);
       });
     });
   });

--- a/src/games/utils/pick-teams.spec.ts
+++ b/src/games/utils/pick-teams.spec.ts
@@ -1,4 +1,5 @@
 import { pickTeams, PlayerSlot, TeamOverrides } from './pick-teams';
+import { shuffle } from 'lodash';
 
 describe('pickTeams', () => {
   describe('for 2v2', () => {
@@ -112,6 +113,36 @@ describe('pickTeams', () => {
           { playerId: 'j', gameClass: 'demoman', skill: 3, team: 'red' },
           { playerId: 'l', gameClass: 'medic', skill: 4, team: 'red' },
         ]);
+      });
+    });
+
+    describe('issue 456', () => {
+      const players: PlayerSlot[] = [
+        { playerId: 'zinner', gameClass: 'soldier', skill: 4 },
+        { playerId: 'mielzky', gameClass: 'soldier', skill: 2 },
+        { playerId: 'mejf', gameClass: 'demoman', skill: 3 },
+        { playerId: 'wonder', gameClass: 'soldier', skill: 3 },
+        { playerId: 'stan', gameClass: 'medic', skill: 4 },
+        { playerId: 'cieniu97', gameClass: 'demoman', skill: 2 },
+        { playerId: 'bobair', gameClass: 'medic', skill: 1 },
+        { playerId: 'kwq', gameClass: 'scout', skill: 7 },
+        { playerId: 'antro15cm', gameClass: 'scout', skill: 2 },
+        { playerId: 'graba', gameClass: 'scout', skill: 4 },
+        { playerId: 'crzje', gameClass: 'scout', skill: 4 },
+        { playerId: 'loww', gameClass: 'soldier', skill: 3 },
+      ];
+
+      console.log(players);
+
+      const overrides: TeamOverrides = {
+        friends: [
+          ['bobair', 'kwq'],
+          ['stan', 'zinner'],
+        ],
+      };
+
+      it.only('should pick teams', () => {
+        expect(pickTeams(players, overrides)).toEqual([]);
       });
     });
   });

--- a/src/games/utils/pick-teams.ts
+++ b/src/games/utils/pick-teams.ts
@@ -92,6 +92,7 @@ function makeAllPossibleLineups(gameClasses: string[], players: PlayerSlot[]): P
   }
 
   makeLineup();
+  console.log(JSON.stringify(possibleLineups, null, 2));
   return possibleLineups;
 }
 

--- a/src/games/utils/pick-teams.ts
+++ b/src/games/utils/pick-teams.ts
@@ -66,6 +66,10 @@ function makeAllPossibleLineups(gameClasses: string[], players: PlayerSlot[]): P
           0: { lineup: [ playersOfGameClass[0], playersOfGameClass[3] ] },
           1: { lineup: [ playersOfGameClass[1], playersOfGameClass[2] ] },
         },
+        {
+          0: { lineup: [ playersOfGameClass[2], playersOfGameClass[3] ] },
+          1: { lineup: [ playersOfGameClass[0], playersOfGameClass[1] ] },
+        },
       ]);
     } else {
       throw new NotImplementedException('more than two players of one class in a team is not implemented');
@@ -92,7 +96,6 @@ function makeAllPossibleLineups(gameClasses: string[], players: PlayerSlot[]): P
   }
 
   makeLineup();
-  console.log(JSON.stringify(possibleLineups, null, 2));
   return possibleLineups;
 }
 


### PR DESCRIPTION
Fixes #456 