### PR TITLE
fix: don't add replaced players

### DIFF
--- a/src/games/models/game.ts
+++ b/src/games/models/game.ts
@@ -55,4 +55,8 @@ export class Game {
     return this.slots.find(s => _playerId.equals(s.player as ObjectId));
   }
 
+  activeSlots() {
+    return this.slots.filter(slot => slot.status.match(/active|waiting for substitute/));
+  }
+
 }

--- a/src/games/services/server-configurator.service.ts
+++ b/src/games/services/server-configurator.service.ts
@@ -70,7 +70,7 @@ export class ServerConfiguratorService {
       this.logger.debug(`[${server.name}] settings password to ${password}...`);
       await rcon.send(setPassword(password));
 
-      for (const slot of game.slots) {
+      for (const slot of game.activeSlots()) {
         const player = isRefType(slot.player) ? await this.playersService.getById(slot.player) : slot.player;
 
         const playerName = deburr(player.name);


### PR DESCRIPTION
When configuring the game server, don't add players that were subbed out.