### PR TITLE
fix(game-servers): don't remove game servers permamently

### DIFF
--- a/src/game-servers/controllers/game-servers.controller.spec.ts
+++ b/src/game-servers/controllers/game-servers.controller.spec.ts
@@ -71,7 +71,7 @@ describe('GameServers Controller', () => {
 
   describe('#removeGameServer()', () => {
     beforeEach(() => {
-      gameServersService.removeGameServer.mockResolvedValue();
+      gameServersService.removeGameServer.mockResolvedValue(mockGameServer);
     });
 
     it('should call the service', async () => {

--- a/src/game-servers/models/game-server.ts
+++ b/src/game-servers/models/game-server.ts
@@ -41,4 +41,8 @@ export class GameServer extends MongooseDocument {
   @prop({ ref: () => Game })
   game?: Ref<Game>; // currently running game
 
+  @Exclude({ toPlainOnly: true })
+  @prop({ default: false })
+  deleted?: boolean;
+
 }


### PR DESCRIPTION
Instead of removing the game server from the database, just mark them as deleted. That way, we don't lose information about old games played on already non-existent game servers.