### PR TITLE
feat(game-servers): update game server

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -63,8 +63,9 @@ export class Events {
     gameServer: GameServer;
     adminId?: string;
   }>();
-  readonly gameServerRemoved = new Subject<{
-    gameServer: GameServer;
+  readonly gameServerUpdated = new Subject<{
+    oldGameServer: GameServer;
+    newGameServer: GameServer;
     adminId?: string;
   }>();
 

--- a/src/game-servers/controllers/game-servers.controller.spec.ts
+++ b/src/game-servers/controllers/game-servers.controller.spec.ts
@@ -94,6 +94,29 @@ describe('GameServers Controller', () => {
     });
   });
 
+  describe('#updateGameServer()', () => {
+    beforeEach(() => {
+      gameServersService.updateGameServer.mockImplementation(
+        (gameServerId, update) => {
+          return Promise.resolve({ ...mockGameServer, update });
+        },
+      );
+    });
+
+    it('should call the service', async () => {
+      await controller.updateGameServer(
+        'FAKE_ID',
+        { name: 'update game server' },
+        { id: 'FAKE_ADMIN_ID' } as Player,
+      );
+      expect(gameServersService.updateGameServer).toHaveBeenCalledWith(
+        'FAKE_ID',
+        { name: 'update game server' },
+        'FAKE_ADMIN_ID',
+      );
+    });
+  });
+
   describe('#removeGameServer()', () => {
     beforeEach(() => {
       gameServersService.removeGameServer.mockResolvedValue(mockGameServer);

--- a/src/game-servers/controllers/game-servers.controller.ts
+++ b/src/game-servers/controllers/game-servers.controller.ts
@@ -11,6 +11,7 @@ import {
   ClassSerializerInterceptor,
   UseFilters,
   HttpCode,
+  Patch,
 } from '@nestjs/common';
 import { GameServersService } from '../services/game-servers.service';
 import { ObjectIdValidationPipe } from '@/shared/pipes/object-id-validation.pipe';
@@ -22,6 +23,7 @@ import { Environment } from '@/environment/environment';
 import { User } from '@/auth/decorators/user.decorator';
 import { Player } from '@/players/models/player';
 import { PlayerRole } from '@/players/models/player-role';
+import { UpdateGameServer } from '../dto/update-game-server';
 
 @Controller('game-servers')
 export class GameServersController {
@@ -57,8 +59,26 @@ export class GameServersController {
     return this.gameServersService.addGameServer(gameServer, admin.id);
   }
 
+  @Patch(':id')
+  @Auth(PlayerRole.superUser)
+  @UsePipes(ValidationPipe)
+  @UseInterceptors(ClassSerializerInterceptor)
+  @UseFilters(DocumentNotFoundFilter)
+  async updateGameServer(
+    @Param('id', ObjectIdValidationPipe) gameServerId: string,
+    @Body() gameServer: UpdateGameServer,
+    @User() admin: Player,
+  ) {
+    return this.gameServersService.updateGameServer(
+      gameServerId,
+      gameServer,
+      admin.id,
+    );
+  }
+
   @Delete(':id')
   @Auth(PlayerRole.superUser)
+  @UseFilters(DocumentNotFoundFilter)
   async removeGameServer(
     @Param('id', ObjectIdValidationPipe) gameServerId: string,
     @User() admin: Player,
@@ -68,6 +88,7 @@ export class GameServersController {
 
   @Post(':id/diagnostics')
   @Auth(PlayerRole.superUser)
+  @UseFilters(DocumentNotFoundFilter)
   @HttpCode(202)
   async runDiagnostics(
     @Param('id', ObjectIdValidationPipe) gameServerId: string,

--- a/src/game-servers/dto/update-game-server.ts
+++ b/src/game-servers/dto/update-game-server.ts
@@ -1,0 +1,20 @@
+import { Optional } from '@nestjs/common';
+import { IsPort, IsString } from 'class-validator';
+
+export class UpdateGameServer {
+  @Optional()
+  @IsString()
+  name?: string;
+
+  @Optional()
+  @IsString()
+  address?: string;
+
+  @Optional()
+  @IsPort()
+  port?: string;
+
+  @Optional()
+  @IsString()
+  rconPassword?: string;
+}

--- a/src/game-servers/services/game-servers.service.spec.ts
+++ b/src/game-servers/services/game-servers.service.spec.ts
@@ -175,6 +175,39 @@ describe('GameServersService', () => {
       }));
   });
 
+  describe('#updateGameServer()', () => {
+    it('should update the game server', async () => {
+      const ret = await service.updateGameServer(testGameServer.id, {
+        name: 'updated game server',
+      });
+      expect(ret.name).toEqual('updated game server');
+      expect((await gameServerModel.findById(testGameServer.id)).name).toEqual(
+        'updated game server',
+      );
+    });
+
+    it('should emit the gameServerUpdated event', async () => {
+      let givenGameServerId: string;
+      let givenGameServerName: string;
+      let givenAdminId: string;
+
+      events.gameServerUpdated.subscribe(({ newGameServer, adminId }) => {
+        givenGameServerId = newGameServer.id;
+        givenGameServerName = newGameServer.name;
+        givenAdminId = adminId;
+      });
+
+      await service.updateGameServer(
+        testGameServer.id,
+        { name: 'updated game server' },
+        'FAKE_ADMIN_ID',
+      );
+      expect(givenGameServerId).toEqual(testGameServer.id);
+      expect(givenGameServerName).toEqual('updated game server');
+      expect(givenAdminId).toEqual('FAKE_ADMIN_ID');
+    });
+  });
+
   describe('#removeGameServer()', () => {
     it('should mark the given game server as deleted', async () => {
       const ret = await service.removeGameServer(testGameServer.id);
@@ -182,16 +215,19 @@ describe('GameServersService', () => {
       expect((await gameServerModel.findById(ret.id)).deleted).toBe(true);
     });
 
-    it('should emit the gameServerRemoved event', async () =>
-      new Promise<void>((resolve) => {
-        events.gameServerRemoved.subscribe(({ gameServer, adminId }) => {
-          expect(gameServer.id).toEqual(testGameServer.id);
-          expect(adminId).toEqual('FAKE_ADMIN_ID');
-          resolve();
-        });
+    it('should emit the gameServerUpdated event', async () => {
+      let givenGameServerId: string;
+      let givenAdminId: string;
 
-        service.removeGameServer(testGameServer.id, 'FAKE_ADMIN_ID');
-      }));
+      events.gameServerUpdated.subscribe(({ newGameServer, adminId }) => {
+        givenGameServerId = newGameServer.id;
+        givenAdminId = adminId;
+      });
+
+      await service.removeGameServer(testGameServer.id, 'FAKE_ADMIN_ID');
+      expect(givenGameServerId).toEqual(testGameServer.id);
+      expect(givenAdminId).toEqual('FAKE_ADMIN_ID');
+    });
   });
 
   describe('#findFreeGameServer()', () => {

--- a/src/plugins/discord/services/admin-notifications.service.spec.ts
+++ b/src/plugins/discord/services/admin-notifications.service.spec.ts
@@ -276,7 +276,7 @@ describe('AdminNotificationsService', () => {
       }));
   });
 
-  describe('when the gameServerRemoved event emits', () => {
+  describe('when the gameServer is removed', () => {
     let admin: Player;
 
     beforeEach(async () => {
@@ -284,19 +284,24 @@ describe('AdminNotificationsService', () => {
       admin = await playersService._createOne();
     });
 
-    it('should send a message', async () =>
-      new Promise<void>((resolve) => {
-        sentMessages.subscribe((message) => {
-          expect(message.embed).toBeTruthy();
-          expect(message.embed.title).toEqual('Game server removed');
-          resolve();
-        });
+    it('should send a message', async () => {
+      sentMessages.subscribe((message) => {
+        expect(message.embed).toBeTruthy();
+        expect(message.embed.title).toEqual('Game server removed');
+      });
 
-        events.gameServerRemoved.next({
-          gameServer: { name: 'fake game server' } as GameServer,
-          adminId: admin.id,
-        });
-      }));
+      events.gameServerUpdated.next({
+        oldGameServer: {
+          name: 'fake game server',
+          deleted: false,
+        } as GameServer,
+        newGameServer: {
+          name: 'fake game server',
+          deleted: true,
+        } as GameServer,
+        adminId: admin.id,
+      });
+    });
   });
 
   describe('when a game is force-ended', () => {

--- a/src/plugins/discord/services/admin-notifications.service.ts
+++ b/src/plugins/discord/services/admin-notifications.service.ts
@@ -73,9 +73,17 @@ export class AdminNotificationsService implements OnModuleInit {
     this.events.gameServerAdded.subscribe(({ gameServer, adminId }) =>
       this.onGameServerAdded(gameServer, adminId),
     );
-    this.events.gameServerRemoved.subscribe(({ gameServer, adminId }) =>
-      this.onGameServerRemoved(gameServer, adminId),
-    );
+    this.events.gameServerUpdated
+      .pipe(
+        filter(
+          ({ oldGameServer, newGameServer }) =>
+            oldGameServer.deleted === false && newGameServer.deleted === true,
+        ),
+      )
+      .subscribe(({ newGameServer, adminId }) =>
+        this.onGameServerRemoved(newGameServer, adminId),
+      );
+
     this.events.gameChanges
       .pipe(
         distinctUntilChanged((x, y) => x.game.state === y.game.state),


### PR DESCRIPTION
Implement `PATCH /game-servers/:id` route that can be used to update
gameserver entry. Get rid of gameServerRemoved event in favor of
gameServerUpdated event.