### PR TITLE
fix(games): better player substitute events

### DIFF
--- a/e2e/player-substitutes-himself.e2e-spec.ts
+++ b/e2e/player-substitutes-himself.e2e-spec.ts
@@ -18,6 +18,7 @@ describe('Player substitutes himself (e2e)', () => {
   let adminToken: string;
   let gameId: string;
   let playerSocket: Socket;
+  let substituteRequests: any[];
 
   beforeAll(async () => {
     const moduleFixture = await Test.createTestingModule({
@@ -48,6 +49,12 @@ describe('Player substitutes himself (e2e)', () => {
       {
         auth: { token: `Bearer ${playerToken}` },
       },
+    );
+
+    substituteRequests = [];
+    playerSocket.on(
+      'substitute requests update',
+      (requests) => (substituteRequests = requests),
     );
   });
 
@@ -147,6 +154,7 @@ describe('Player substitutes himself (e2e)', () => {
   });
 
   it('should substitute a player', async () => {
+    expect(substituteRequests.length).toEqual(0);
     const player = await playersService.findBySteamId(players[1]);
 
     // admin requests substitute
@@ -163,6 +171,8 @@ describe('Player substitutes himself (e2e)', () => {
         const slot = body.slots.find((s) => s.player === player.id);
         expect(slot.status).toEqual('waiting for substitute');
       });
+
+    expect(substituteRequests.length).toEqual(1);
 
     // player substitutes himself
     await new Promise<void>((resolve) => {
@@ -182,5 +192,7 @@ describe('Player substitutes himself (e2e)', () => {
         const body = response.body;
         expect(body.slots.every((s) => s.status === 'active')).toBe(true);
       });
+
+    expect(substituteRequests.length).toEqual(0);
   });
 });

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -71,6 +71,9 @@ export class Events {
     replaceeId: string;
     replacementId: string;
   }>();
+  /**
+   * @deprecated
+   */
   readonly substituteRequestsChange = new Subject<void>();
 
   readonly gameServerAdded = new Subject<{

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -4,6 +4,7 @@ import { Player } from '@/players/models/player';
 import { PlayerBan } from '@/players/models/player-ban';
 import { PlayerSkillType } from '@/players/services/player-skill.service';
 import { Map } from '@/queue/models/map';
+import { string } from '@hapi/joi';
 import { Injectable, Logger } from '@nestjs/common';
 import { Subject } from 'rxjs';
 import { MapVoteResult } from '../queue/map-vote-result';
@@ -57,6 +58,20 @@ export class Events {
 
   readonly gameCreated = new Subject<{ game: Game }>();
   readonly gameChanges = new Subject<{ game: Game; adminId?: string }>();
+
+  readonly substituteRequested = new Subject<{
+    gameId: string;
+    playerId: string;
+  }>();
+  readonly substituteCanceled = new Subject<{
+    gameId: string;
+    playerId: string;
+  }>();
+  readonly playerReplaced = new Subject<{
+    gameId: string;
+    replaceeId: string;
+    replacementId: string;
+  }>();
   readonly substituteRequestsChange = new Subject<void>();
 
   readonly gameServerAdded = new Subject<{

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -4,7 +4,6 @@ import { Player } from '@/players/models/player';
 import { PlayerBan } from '@/players/models/player-ban';
 import { PlayerSkillType } from '@/players/services/player-skill.service';
 import { Map } from '@/queue/models/map';
-import { string } from '@hapi/joi';
 import { Injectable, Logger } from '@nestjs/common';
 import { Subject } from 'rxjs';
 import { MapVoteResult } from '../queue/map-vote-result';

--- a/src/games/services/player-substitution.service.spec.ts
+++ b/src/games/services/player-substitution.service.spec.ts
@@ -197,14 +197,17 @@ describe('PlayerSubstitutionService', () => {
       );
     });
 
-    it('should emit the substituteRequestsChange event', async () => {
-      let eventEmitted = false;
-      events.substituteRequestsChange.subscribe(() => {
-        eventEmitted = true;
+    it('should emit the substituteRequested event', async () => {
+      let emittedGameId: string;
+      let emittedPlayerId: string;
+      events.substituteRequested.subscribe(({ gameId, playerId }) => {
+        emittedGameId = gameId;
+        emittedPlayerId = playerId;
       });
 
       await service.substitutePlayer(mockGame.id, player1.id);
-      expect(eventEmitted).toBe(true);
+      expect(emittedGameId).toEqual(mockGame.id);
+      expect(emittedPlayerId).toEqual(player1.id);
     });
 
     it('should do nothing if the player is already marked', async () => {
@@ -294,14 +297,17 @@ describe('PlayerSubstitutionService', () => {
       });
     });
 
-    it('should emit the substituteRequestsChange event', async () => {
-      let eventEmitted = false;
-      events.substituteRequestsChange.subscribe(() => {
-        eventEmitted = true;
+    it('should emit the substituteCanceled event', async () => {
+      let emittedGameId: string;
+      let emittedPlayerId: string;
+      events.substituteCanceled.subscribe(({ gameId, playerId }) => {
+        emittedGameId = gameId;
+        emittedPlayerId = playerId;
       });
 
       await service.cancelSubstitutionRequest(mockGame.id, player1.id);
-      expect(eventEmitted).toBe(true);
+      expect(emittedGameId).toEqual(mockGame.id);
+      expect(emittedPlayerId).toEqual(player1.id);
     });
 
     it('should get rid of discord announcement', async () => {
@@ -438,14 +444,23 @@ describe('PlayerSubstitutionService', () => {
       });
     });
 
-    it('should emit the substituteRequestsChange event', async () => {
-      let eventEmitted = false;
-      events.substituteRequestsChange.subscribe(() => {
-        eventEmitted = true;
-      });
+    it('should emit the playerReplaced event', async () => {
+      let emittedGameId: string;
+      let emittedReplaceeId: string;
+      let emittedReplacementId: string;
+
+      events.playerReplaced.subscribe(
+        ({ gameId, replaceeId, replacementId }) => {
+          emittedGameId = gameId;
+          emittedReplaceeId = replaceeId;
+          emittedReplacementId = replacementId;
+        },
+      );
 
       await service.replacePlayer(mockGame.id, player1.id, player3.id);
-      expect(eventEmitted).toBe(true);
+      expect(emittedGameId).toEqual(mockGame.id);
+      expect(emittedReplaceeId).toEqual(player1.id);
+      expect(emittedReplacementId).toEqual(player3.id);
     });
 
     it('should reject if the replacement player does not exist', async () => {

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -24,7 +24,7 @@ import { plainToClass } from 'class-transformer';
 import { PlayerNotInThisGameError } from '../errors/player-not-in-this-game.error';
 import { GameInWrongStateError } from '../errors/game-in-wrong-state.error';
 import { WrongGameSlotStatusError } from '../errors/wrong-game-slot-status.error';
-import { merge } from 'lodash';
+import { merge } from 'rxjs';
 
 /**
  * A service that handles player substitution logic.


### PR DESCRIPTION
Implement `substituteRequested`, `substituteCanceled` and `playerReplaced` events.
Do not get rid of the `substituteRequestsChange` event as of now, although mark it as deprecated.