### PR TITLE
refactor(*): improve code quality in playerservice, use rxjs 9 syntax

### DIFF
--- a/src/players/services/etf2l-profile.service.ts
+++ b/src/players/services/etf2l-profile.service.ts
@@ -21,7 +21,7 @@ export class Etf2lProfileService {
 
   // TODO This is steamId or etf2lProfileId
   async fetchPlayerInfo(steamId: string): Promise<Etf2lProfile> {
-    const profile$ = this.httpService
+    const profile = this.httpService
       .get<Etf2lPlayerResponse>(`${this.etf2lEndpoint}/player/${steamId}.json`)
       .pipe(
         catchError((error) => {
@@ -53,6 +53,6 @@ export class Etf2lProfileService {
         }),
       );
 
-    return await firstValueFrom(profile$);
+    return await firstValueFrom(profile);
   }
 }

--- a/src/players/services/etf2l-profile.service.ts
+++ b/src/players/services/etf2l-profile.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Etf2lProfile } from '../etf2l-profile';
 import { switchMap, catchError } from 'rxjs/operators';
-import { of, throwError } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import { NoEtf2lAccountError } from '../errors/no-etf2l-account.error';
 
@@ -21,7 +21,7 @@ export class Etf2lProfileService {
 
   // TODO This is steamId or etf2lProfileId
   async fetchPlayerInfo(steamId: string): Promise<Etf2lProfile> {
-    return this.httpService
+    const profile$ = this.httpService
       .get<Etf2lPlayerResponse>(`${this.etf2lEndpoint}/player/${steamId}.json`)
       .pipe(
         catchError((error) => {
@@ -51,7 +51,8 @@ export class Etf2lProfileService {
             }
           }
         }),
-      )
-      .toPromise();
+      );
+
+    return await firstValueFrom(profile$);
   }
 }

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -228,27 +228,20 @@ export class PlayersService implements OnModuleInit {
   }
 
   private async verifyTf2InGameHours(steamId: string) {
-    const minimumTf2InGameHours = (
-      await this.configurationService.getMinimumTf2InGameHours()
-    ).value;
-    try {
-      const hoursInTf2 = await this.steamApiService.getTf2InGameHours(steamId);
-      if (hoursInTf2 < minimumTf2InGameHours) {
-        throw new InsufficientTf2InGameHoursError(
-          steamId,
-          minimumTf2InGameHours,
-          hoursInTf2,
-        );
-      }
-    } catch (error) {
-      if (
-        error instanceof Tf2InGameHoursVerificationError &&
-        minimumTf2InGameHours <= 0
-      ) {
-        return;
-      } else {
-        throw error;
-      }
+    const { value: minimumTf2InGameHours } =
+      await this.configurationService.getMinimumTf2InGameHours();
+
+    if (minimumTf2InGameHours <= 0) {
+      return;
+    }
+
+    const hoursInTf2 = await this.steamApiService.getTf2InGameHours(steamId);
+    if (hoursInTf2 < minimumTf2InGameHours) {
+      throw new InsufficientTf2InGameHoursError(
+        steamId,
+        minimumTf2InGameHours,
+        hoursInTf2,
+      );
     }
   }
 }

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -119,7 +119,10 @@ export class PlayersService implements OnModuleInit {
     let etf2lProfile: Etf2lProfile;
     let name = steamProfile.displayName;
 
-    try {
+    const { value: isEtf2lAccountRequired } =
+      await this.configurationService.isEtf2lAccountRequired();
+
+    if (isEtf2lAccountRequired) {
       etf2lProfile = await this.etf2lProfileService.fetchPlayerInfo(
         steamProfile.id,
       );
@@ -132,13 +135,6 @@ export class PlayersService implements OnModuleInit {
       }
 
       name = etf2lProfile.name;
-    } catch (error) {
-      const isEtf2lAccountRequired = (
-        await this.configurationService.isEtf2lAccountRequired()
-      ).value;
-      if (isEtf2lAccountRequired) {
-        throw error;
-      }
     }
 
     const avatar: PlayerAvatar = {

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -169,19 +169,15 @@ export class PlayersService implements OnModuleInit {
   async forceCreatePlayer(
     playerData: ForceCreatePlayerOptions,
   ): Promise<Player> {
-    let etf2lProfile: Etf2lProfile;
-    try {
-      etf2lProfile = await this.etf2lProfileService.fetchPlayerInfo(
-        playerData.steamId,
-      );
-    } catch (error) {
-      etf2lProfile = undefined;
-    }
+    const etf2lProfile =
+      (await this.etf2lProfileService.fetchPlayerInfo(playerData.steamId)) ??
+      undefined;
 
     const { id } = await this.playerModel.create({
       etf2lProfileId: etf2lProfile?.id,
       ...playerData,
     });
+
     const player = await this.getById(id);
     this.logger.verbose(`created new player (name: ${player.name})`);
     this.events.playerRegisters.next({ player });

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -122,13 +122,9 @@ export class PlayersService implements OnModuleInit {
       await this.configurationService.isEtf2lAccountRequired();
 
     if (isEtf2lAccountRequired) {
-      etf2lProfile = await this.etf2lProfileService
-        .fetchPlayerInfo(steamProfile.id)
-        .catch((err) => {
-          // Either we get a missing profile exception, or a 500 exception (from api).
-          // Just throw it to keep old behavior
-          throw err;
-        });
+      etf2lProfile = await this.etf2lProfileService.fetchPlayerInfo(
+        steamProfile.id,
+      );
 
       if (
         etf2lProfile.bans?.filter((ban) => ban.end > Date.now() / 1000).length >

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -24,7 +24,6 @@ import { InsufficientTf2InGameHoursError } from '../errors/insufficient-tf2-in-g
 import { PlayerRole } from '../models/player-role';
 import { ConfigurationService } from '@/configuration/services/configuration.service';
 import { InjectModel } from '@nestjs/mongoose';
-import { NoEtf2lAccountError } from '../errors/no-etf2l-account.error';
 
 type ForceCreatePlayerOptions = Pick<Player, 'steamId' | 'name'>;
 

--- a/src/players/services/steam-api.service.ts
+++ b/src/players/services/steam-api.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Environment } from '@/environment/environment';
 import { map, switchMap, catchError } from 'rxjs/operators';
 import { floor } from 'lodash';
-import { of, throwError } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
 import { Tf2InGameHoursVerificationError } from '../errors/tf2-in-game-hours-verification.error';
 import { HttpService } from '@nestjs/axios';
 
@@ -28,7 +28,7 @@ export class SteamApiService {
   ) {}
 
   async getTf2InGameHours(steamId64: string): Promise<number> {
-    return this.httpService
+    const hours$ = this.httpService
       .get<UserStatsForGameResponse>(
         `${this.userStatsForGameEndpoint}/?appid=${this.tf2AppId}&key=${this.environment.steamApiKey}&steamid=${steamId64}&format=json`,
       )
@@ -46,7 +46,8 @@ export class SteamApiService {
             () => new Tf2InGameHoursVerificationError(steamId64, error),
           ),
         ),
-      )
-      .toPromise();
+      );
+
+    return await firstValueFrom(hours$);
   }
 }

--- a/src/players/services/steam-api.service.ts
+++ b/src/players/services/steam-api.service.ts
@@ -28,7 +28,7 @@ export class SteamApiService {
   ) {}
 
   async getTf2InGameHours(steamId64: string): Promise<number> {
-    const hours$ = this.httpService
+    const hours = this.httpService
       .get<UserStatsForGameResponse>(
         `${this.userStatsForGameEndpoint}/?appid=${this.tf2AppId}&key=${this.environment.steamApiKey}&steamid=${steamId64}&format=json`,
       )
@@ -48,6 +48,6 @@ export class SteamApiService {
         ),
       );
 
-    return await firstValueFrom(hours$);
+    return await firstValueFrom(hours);
   }
 }

--- a/src/plugins/twitch/services/twitch-auth.service.ts
+++ b/src/plugins/twitch/services/twitch-auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Environment } from '@/environment/environment';
 import { map } from 'rxjs/operators';
 import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
 
 interface TokenResponse {
   access_token: string;
@@ -47,7 +48,7 @@ export class TwitchAuthService {
   }
 
   async fetchUserAccessToken(code: string) {
-    return this.httpService
+    const token$ = this.httpService
       .post<TokenResponse>(
         `${twitchOauth2TokenUrl}` +
           `?client_id=${this.environment.twitchClientId}` +
@@ -56,8 +57,9 @@ export class TwitchAuthService {
           `&grant_type=authorization_code` +
           `&redirect_uri=${this.redirectUri}`,
       )
-      .pipe(map((response) => response.data.access_token))
-      .toPromise();
+      .pipe(map((response) => response.data.access_token));
+
+    return await firstValueFrom(token$);
   }
 
   async getAppAccessToken() {
@@ -80,8 +82,8 @@ export class TwitchAuthService {
     return this.appAccessToken;
   }
 
-  private fetchAppAccessToken() {
-    return this.httpService
+  private async fetchAppAccessToken() {
+    const appAccess$ = this.httpService
       .post<AppAccessTokenResponse>(
         twitchOauth2TokenUrl,
         {},
@@ -98,7 +100,8 @@ export class TwitchAuthService {
           accessToken: response.data.access_token,
           expiresIn: response.data.expires_in,
         })),
-      )
-      .toPromise();
+      );
+
+    return await firstValueFrom(appAccess$);
   }
 }

--- a/src/plugins/twitch/services/twitch-auth.service.ts
+++ b/src/plugins/twitch/services/twitch-auth.service.ts
@@ -48,7 +48,7 @@ export class TwitchAuthService {
   }
 
   async fetchUserAccessToken(code: string) {
-    const token$ = this.httpService
+    const token = this.httpService
       .post<TokenResponse>(
         `${twitchOauth2TokenUrl}` +
           `?client_id=${this.environment.twitchClientId}` +
@@ -59,7 +59,7 @@ export class TwitchAuthService {
       )
       .pipe(map((response) => response.data.access_token));
 
-    return await firstValueFrom(token$);
+    return await firstValueFrom(token);
   }
 
   async getAppAccessToken() {
@@ -83,7 +83,7 @@ export class TwitchAuthService {
   }
 
   private async fetchAppAccessToken() {
-    const appAccess$ = this.httpService
+    const appAccess = this.httpService
       .post<AppAccessTokenResponse>(
         twitchOauth2TokenUrl,
         {},
@@ -102,6 +102,6 @@ export class TwitchAuthService {
         })),
       );
 
-    return await firstValueFrom(appAccess$);
+    return await firstValueFrom(appAccess);
   }
 }

--- a/src/plugins/twitch/services/twitch.service.ts
+++ b/src/plugins/twitch/services/twitch.service.ts
@@ -3,7 +3,7 @@ import { TwitchStream } from '../models/twitch-stream';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Environment } from '@/environment/environment';
 import { map, distinctUntilChanged } from 'rxjs/operators';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { TwitchGateway } from '../gateways/twitch.gateway';
 import { TwitchAuthService } from './twitch-auth.service';
 import { PlayerBansService } from '@/players/services/player-bans.service';
@@ -103,15 +103,16 @@ export class TwitchService implements OnModuleInit {
 
   async fetchUserProfile(accessToken: string) {
     // https://dev.twitch.tv/docs/api/reference#get-users
-    return this.httpService
+    const accessToken$ = this.httpService
       .get<TwitchGetUsersResponse>(`${twitchTvApiEndpoint}/users`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           'Client-ID': this.environment.twitchClientId,
         },
       })
-      .pipe(map((response) => response.data.data[0]))
-      .toPromise();
+      .pipe(map((response) => response.data.data[0]));
+
+    return await firstValueFrom(accessToken$);
   }
 
   async saveUserProfile(playerId: string, code: string) {
@@ -147,6 +148,7 @@ export class TwitchService implements OnModuleInit {
       userIds: users.map((user) => user.userId),
       userLogins: promotedStreams,
     });
+    
     const streams = (
       await Promise.all(
         rawStreams.map(async (stream) => {
@@ -184,6 +186,7 @@ export class TwitchService implements OnModuleInit {
         }),
       )
     ).filter((stream) => !!stream);
+
     this._streams.next(streams);
     this.logger.debug('streams refreshed');
   }
@@ -193,7 +196,7 @@ export class TwitchService implements OnModuleInit {
     userLogins: string[];
   }) {
     // https://dev.twitch.tv/docs/api/reference#get-streams
-    return this.httpService
+    const streams$ = this.httpService
       .get<TwitchGetStreamsResponse>(`${twitchTvApiEndpoint}/streams`, {
         params: {
           user_id: params.userIds,
@@ -204,7 +207,8 @@ export class TwitchService implements OnModuleInit {
           Authorization: `Bearer ${await this.twitchAuthService.getAppAccessToken()}`,
         },
       })
-      .pipe(map((response) => response.data.data))
-      .toPromise();
+      .pipe(map((response) => response.data.data));
+
+    return await firstValueFrom(streams$);
   }
 }

--- a/src/plugins/twitch/services/twitch.service.ts
+++ b/src/plugins/twitch/services/twitch.service.ts
@@ -103,7 +103,7 @@ export class TwitchService implements OnModuleInit {
 
   async fetchUserProfile(accessToken: string) {
     // https://dev.twitch.tv/docs/api/reference#get-users
-    const accessToken$ = this.httpService
+    const accessToken = this.httpService
       .get<TwitchGetUsersResponse>(`${twitchTvApiEndpoint}/users`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -112,7 +112,7 @@ export class TwitchService implements OnModuleInit {
       })
       .pipe(map((response) => response.data.data[0]));
 
-    return await firstValueFrom(accessToken$);
+    return await firstValueFrom(accessToken);
   }
 
   async saveUserProfile(playerId: string, code: string) {
@@ -196,7 +196,7 @@ export class TwitchService implements OnModuleInit {
     userLogins: string[];
   }) {
     // https://dev.twitch.tv/docs/api/reference#get-streams
-    const streams$ = this.httpService
+    const streams = this.httpService
       .get<TwitchGetStreamsResponse>(`${twitchTvApiEndpoint}/streams`, {
         params: {
           user_id: params.userIds,
@@ -209,6 +209,6 @@ export class TwitchService implements OnModuleInit {
       })
       .pipe(map((response) => response.data.data));
 
-    return await firstValueFrom(streams$);
+    return await firstValueFrom(streams);
   }
 }

--- a/src/plugins/twitch/services/twitch.service.ts
+++ b/src/plugins/twitch/services/twitch.service.ts
@@ -103,7 +103,7 @@ export class TwitchService implements OnModuleInit {
 
   async fetchUserProfile(accessToken: string) {
     // https://dev.twitch.tv/docs/api/reference#get-users
-    const accessToken = this.httpService
+    const token = this.httpService
       .get<TwitchGetUsersResponse>(`${twitchTvApiEndpoint}/users`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -112,7 +112,7 @@ export class TwitchService implements OnModuleInit {
       })
       .pipe(map((response) => response.data.data[0]));
 
-    return await firstValueFrom(accessToken);
+    return await firstValueFrom(token);
   }
 
   async saveUserProfile(playerId: string, code: string) {

--- a/src/plugins/twitch/services/twitch.service.ts
+++ b/src/plugins/twitch/services/twitch.service.ts
@@ -148,7 +148,7 @@ export class TwitchService implements OnModuleInit {
       userIds: users.map((user) => user.userId),
       userLogins: promotedStreams,
     });
-    
+
     const streams = (
       await Promise.all(
         rawStreams.map(async (stream) => {


### PR DESCRIPTION
2 things:

We remove unneeded try/catches in the PlayerService, and we use rxjs 9 syntax for promises (first/last valueFrom)

Small changes to hopefully in the future allow for multiple league support for account requirements, and general readability improvements.

https://indepth.dev/posts/1287/rxjs-heads-up-topromise-is-being-deprecated#why-is-this-happening-to-me

Unblocks the upgrading to Rxjs 9+. Also can unblock the ability to add additional league account support.