### PR TITLE
feat(game-servers): Improve available gameserver detection

### DIFF
--- a/migrations/1635887923233-add-endedAt-to-game.js
+++ b/migrations/1635887923233-add-endedAt-to-game.js
@@ -17,18 +17,3 @@ module.exports.up = (next) => {
     )
     .then(() => next());
 };
-
-module.exports.down = (next) => {
-  config();
-
-  MongoClient.connect(process.env.MONGODB_URI, { useUnifiedTopology: true })
-    .then((client) => client.db())
-    .then((db) => db.collection('games'))
-    .then((collection) =>
-      Promise.all([
-        collection,
-        collection.updateMany({}, { $unset: { endedAt: "" } }),
-      ]),
-    )
-    .then(() => next());
-};

--- a/migrations/1635887923233-add-endedAt-to-game.js
+++ b/migrations/1635887923233-add-endedAt-to-game.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { config } = require('dotenv');
+const { MongoClient } = require('mongodb');
+
+module.exports.up = (next) => {
+  config();
+
+  MongoClient.connect(process.env.MONGODB_URI, { useUnifiedTopology: true })
+    .then((client) => client.db())
+    .then((db) => db.collection('games'))
+    .then((collection) =>
+      Promise.all([
+        collection,
+        collection.updateMany({}, { $set: { endedAt: { $add: ["$launchedAt", 1000 * 60 * 45]} } }),
+      ]),
+    )
+    .then(() => next());
+};
+
+module.exports.down = (next) => {
+  config();
+
+  MongoClient.connect(process.env.MONGODB_URI, { useUnifiedTopology: true })
+    .then((client) => client.db())
+    .then((db) => db.collection('games'))
+    .then((collection) =>
+      Promise.all([
+        collection,
+        collection.updateMany({}, { $unset: { endedAt: "" } }),
+      ]),
+    )
+    .then(() => next());
+};

--- a/src/game-servers/services/game-servers.service.spec.ts
+++ b/src/game-servers/services/game-servers.service.spec.ts
@@ -17,6 +17,7 @@ import {
   MongooseModule,
 } from '@nestjs/mongoose';
 import { GamesService } from '@/games/services/games.service';
+import { GameState } from '@/games/models/game-state';
 
 jest.mock('@/games/services/games.service');
 
@@ -200,7 +201,14 @@ describe('GameServersService', () => {
   describe('#findFreeGameServer()', () => {
     describe('when the server is online but taken', () => {
       beforeEach(async () => {
-        testGameServer.game = new ObjectId();
+        const game1 = await gameModel.create({
+          number: 2,
+          map: 'cp_badlands',
+          slots: [],
+          state: GameState.started
+        });
+
+        testGameServer.game = new ObjectId(game1.id);
         testGameServer.isOnline = true;
         await testGameServer.save();
       });
@@ -208,6 +216,28 @@ describe('GameServersService', () => {
       it('should throw an error', async () => {
         await expect(service.findFreeGameServer()).rejects.toThrow(
           Error.DocumentNotFoundError,
+        );
+      });
+    });
+
+    describe('when the server has a game, but that game ended', () => {
+      beforeEach(async () => {
+
+        const game2 = await gameModel.create({
+          number: 2,
+          map: 'cp_badlands',
+          slots: [],
+          state: GameState.ended
+        });
+
+        testGameServer.game = new ObjectId(game2.id);
+        testGameServer.isOnline = true;
+        await testGameServer.save();
+      });
+
+      it('should return this game server', async () => {
+        expect((await service.findFreeGameServer()).id).toEqual(
+          testGameServer.id,
         );
       });
     });

--- a/src/game-servers/services/game-servers.service.spec.ts
+++ b/src/game-servers/services/game-servers.service.spec.ts
@@ -205,7 +205,7 @@ describe('GameServersService', () => {
           number: 2,
           map: 'cp_badlands',
           slots: [],
-          state: GameState.started
+          state: GameState.started,
         });
 
         testGameServer.game = new ObjectId(game1.id);
@@ -214,20 +214,19 @@ describe('GameServersService', () => {
       });
 
       it('should throw an error', async () => {
-        await expect(service.findFreeGameServer()).rejects.toThrow(
-          Error.DocumentNotFoundError,
-        );
+        await expect(service.findFreeGameServer()).rejects.toThrowError();
       });
     });
 
-    describe('when the server has a game, but that game ended', () => {
+    describe('when the server has a game, but that game ended long ago', () => {
       beforeEach(async () => {
-
         const game2 = await gameModel.create({
           number: 2,
           map: 'cp_badlands',
           slots: [],
-          state: GameState.ended
+          state: GameState.ended,
+          launchedAt: new Date(1635884999789),
+          endedAt: new Date(1635888599789),
         });
 
         testGameServer.game = new ObjectId(game2.id);
@@ -242,6 +241,27 @@ describe('GameServersService', () => {
       });
     });
 
+    describe('when the server has a game, which ended just now', () => {
+      beforeEach(async () => {
+        const game3 = await gameModel.create({
+          number: 2,
+          map: 'cp_badlands',
+          slots: [],
+          state: GameState.ended,
+          launchedAt: new Date(1635884999789),
+          endedAt: new Date(),
+        });
+
+        testGameServer.game = new ObjectId(game3.id);
+        testGameServer.isOnline = true;
+        await testGameServer.save();
+      });
+
+      it('should throw an error', async () => {
+        await expect(service.findFreeGameServer()).rejects.toThrowError();
+      });
+    });
+
     describe('when the server is free but offline', () => {
       beforeEach(async () => {
         testGameServer.isOnline = false;
@@ -249,9 +269,7 @@ describe('GameServersService', () => {
       });
 
       it('should throw an error', async () => {
-        await expect(service.findFreeGameServer()).rejects.toThrow(
-          Error.DocumentNotFoundError,
-        );
+        await expect(service.findFreeGameServer()).rejects.toThrowError();
       });
     });
 

--- a/src/game-servers/services/game-servers.service.ts
+++ b/src/game-servers/services/game-servers.service.ts
@@ -168,9 +168,11 @@ export class GameServersService implements OnModuleInit {
       if (gameServer.game !== undefined) {
         const game = await this.gamesService.getById(gameServer.game);
 
+        // Check if the game either ended or was interrupted at least 2 minutes ago
         if (
-          game.state === GameState.ended ||
-          game.state === GameState.interrupted
+          (game.state === GameState.ended ||
+            game.state === GameState.interrupted) &&
+          game.endedAt.getTime() < Date.now() - 1000 * 60 * 2
         ) {
           this.logger.debug(
             `game server ${gameServer.id} (${gameServer.name}) had the wrong state of a game`,
@@ -189,7 +191,7 @@ export class GameServersService implements OnModuleInit {
     if (availableGameServer !== null) {
       return availableGameServer;
     } else {
-      throw new Error.DocumentNotFoundError("No free servers available.");
+      throw new Error('No free servers available.');
     }
   }
 

--- a/src/games/controllers/games.controller.spec.ts
+++ b/src/games/controllers/games.controller.spec.ts
@@ -18,6 +18,8 @@ class GamesServiceStub {
       number: 1,
       map: 'cp_fake_rc1',
       state: 'ended',
+      launchedAt: new Date(1635884999789),
+      endedAt: new Date(1635888599789),
       assignedSkills: new Map([['FAKE_PLAYER_ID', 1]]),
     } as Game,
     {

--- a/src/games/models/game.ts
+++ b/src/games/models/game.ts
@@ -15,6 +15,9 @@ export class Game extends MongooseDocument {
   @Prop({ default: () => new Date() })
   launchedAt?: Date;
 
+  @Prop()
+  endedAt?: Date;
+
   @Prop({ required: true, unique: true })
   number!: number;
 

--- a/src/games/services/game-event-handler.service.ts
+++ b/src/games/services/game-event-handler.service.ts
@@ -65,6 +65,7 @@ export class GameEventHandlerService implements OnModuleDestroy {
           { _id: new Types.ObjectId(gameId), state: GameState.started },
           {
             state: GameState.ended,
+            endedAt: new Date(),
             'slots.$[element].status': `${SlotStatus.active}`,
           },
           {

--- a/src/games/services/game-runtime.service.ts
+++ b/src/games/services/game-runtime.service.ts
@@ -71,6 +71,7 @@ export class GameRuntimeService {
           gameId,
           {
             state: GameState.interrupted,
+            endedAt: new Date(),
             error: 'ended by admin',
             'slots.$[element].status': SlotStatus.active,
           },


### PR DESCRIPTION
Sometimes it happens, that a `game server` references a `game`, despite that game not running anymore.

This PR improves the detection of available game servers. Instead if just checking if a game server has a game property, it also loads the game which is attached to the game server to confirm, that the game is still running.

If the game is not running anymore, the game server gets released and returned as available.

Additionally this PR adds a property `endedAt` to the `Game` model. This is used to identify if a cleanup of a game is already finished.

This PR only releases a game server, if the game state is ended or interrupted since at least two minutes.