### PR TITLE
fix(players): set proper roles property for players

### DIFF
--- a/migrations/1636162329824-add-player-roles.js
+++ b/migrations/1636162329824-add-player-roles.js
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+'use strict';
+
+//
+// Follow-up to the extended-player-roles migration.
+//
+
+const { config } = require('dotenv');
+const { MongoClient } = require('mongodb');
+
+module.exports.up = (next) => {
+  config();
+
+  MongoClient.connect(process.env.MONGODB_URI, { useUnifiedTopology: true })
+    .then((client) => client.db())
+    .then((db) => db.collection('players'))
+    .then((collection) =>
+      Promise.all([
+        collection,
+        collection.updateMany(
+          {
+            role: null,
+          },
+          {
+            $set: { roles: [] },
+            $unset: { role: 1 },
+          },
+        ),
+      ]),
+    )
+    .then(() => next());
+};

--- a/migrations/1636162329824-add-player-roles.js
+++ b/migrations/1636162329824-add-player-roles.js
@@ -19,7 +19,7 @@ module.exports.up = (next) => {
         collection,
         collection.updateMany(
           {
-            role: null,
+            roles: { $exists: false },
           },
           {
             $set: { roles: [] },

--- a/src/auth/strategies/steam.strategy.spec.ts
+++ b/src/auth/strategies/steam.strategy.spec.ts
@@ -10,6 +10,7 @@ const mockPlayer: Player = {
   name: 'FAKE_PLAYER',
   steamId: 'FAKE_STEAM_ID',
   hasAcceptedRules: true,
+  roles: [],
   _links: [],
 };
 

--- a/src/players/models/player.ts
+++ b/src/players/models/player.ts
@@ -26,7 +26,7 @@ export class Player extends MongooseDocument {
   avatar?: PlayerAvatar;
 
   @Prop({ type: () => [String], enum: PlayerRole, default: [] })
-  roles?: PlayerRole[];
+  roles!: PlayerRole[];
 
   @Exclude({ toPlainOnly: true })
   @Prop({ default: false })

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -25,7 +25,8 @@ import { PlayerRole } from '../models/player-role';
 import { ConfigurationService } from '@/configuration/services/configuration.service';
 import { InjectModel } from '@nestjs/mongoose';
 
-type ForceCreatePlayerOptions = Pick<Player, 'steamId' | 'name' | 'roles'>;
+type ForceCreatePlayerOptions = Pick<Player, 'steamId' | 'name'> &
+  Partial<Pick<Player, 'roles'>>;
 
 @Injectable()
 export class PlayersService implements OnModuleInit {

--- a/src/players/services/players.service.ts
+++ b/src/players/services/players.service.ts
@@ -25,8 +25,11 @@ import { PlayerRole } from '../models/player-role';
 import { ConfigurationService } from '@/configuration/services/configuration.service';
 import { InjectModel } from '@nestjs/mongoose';
 
-type ForceCreatePlayerOptions = Pick<Player, 'steamId' | 'name'> &
-  Partial<Pick<Player, 'roles'>>;
+interface ForceCreatePlayerOptions {
+  name: Player['name'];
+  steamId: Player['steamId'];
+  roles?: Player['roles'];
+}
 
 @Injectable()
 export class PlayersService implements OnModuleInit {

--- a/src/profile/controllers/profile.controller.spec.ts
+++ b/src/profile/controllers/profile.controller.spec.ts
@@ -74,6 +74,7 @@ describe('Profile Controller', () => {
           steamId: 'FAKE_STEAM_ID',
           linkedProfilesUrl: '',
           _links: [],
+          roles: [],
         },
         bans: [],
         mapVote: 'cp_badlands',
@@ -94,6 +95,7 @@ describe('Profile Controller', () => {
         activeGame: gameId,
         linkedProfilesUrl: '',
         _links: [],
+        roles: [],
       };
       expect(await controller.getProfile(player)).toEqual(
         expect.objectContaining({ activeGameId: gameId.toString() }),


### PR DESCRIPTION
This runs the migration that assigns proper `roles` property to all the players that have the old `role` property set to `null`.