### PR TITLE
feat(discord): dynamic Discord configuration

### DIFF
--- a/e2e/configuration.e2e-spec.ts
+++ b/e2e/configuration.e2e-spec.ts
@@ -261,4 +261,29 @@ describe('Configuration (e2e)', () => {
       },
     });
   });
+
+  it('PUT /configuration/discord', async () => {
+    const response = await request(app.getHttpServer())
+      .put('/configuration/discord')
+      .auth(adminAuthToken, { type: 'bearer' })
+      .send({
+        key: 'discord',
+        servers: [
+          {
+            guildId: '516366706751438868',
+            queueNotificationsChannelId: '892138986406019132',
+          },
+        ],
+      });
+    const body = response.body;
+    expect(body).toEqual({
+      key: 'discord',
+      servers: [
+        {
+          guildId: '516366706751438868',
+          queueNotificationsChannelId: '892138986406019132',
+        },
+      ],
+    });
+  });
 });

--- a/src/configuration/configuration.module.ts
+++ b/src/configuration/configuration.module.ts
@@ -12,6 +12,7 @@ import { whitelistIdSchema } from './models/whitelist-id';
 import { etf2lAccountRequiredSchema } from './models/etf2l-account-required';
 import { minimumTf2InGameHoursSchema } from './models/minimum-tf2-in-game-hours';
 import { voiceServerSchema } from './models/voice-server';
+import { discordSchema } from './models/discord';
 
 @Module({
   imports: [
@@ -40,6 +41,10 @@ import { voiceServerSchema } from './models/voice-server';
             name: ConfigurationEntryKey.voiceServer,
             schema: voiceServerSchema,
           },
+          {
+            name: ConfigurationEntryKey.discord,
+            schema: discordSchema,
+          }
         ],
       },
     ]),

--- a/src/configuration/configuration.module.ts
+++ b/src/configuration/configuration.module.ts
@@ -44,7 +44,7 @@ import { discordSchema } from './models/discord';
           {
             name: ConfigurationEntryKey.discord,
             schema: discordSchema,
-          }
+          },
         ],
       },
     ]),

--- a/src/configuration/controllers/configuration.controller.ts
+++ b/src/configuration/controllers/configuration.controller.ts
@@ -10,6 +10,7 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { DefaultPlayerSkill } from '../models/default-player-skill';
+import { Discord } from '../models/discord';
 import { Etf2lAccountRequired } from '../models/etf2l-account-required';
 import { MinimumTf2InGameHours } from '../models/minimum-tf2-in-game-hours';
 import { VoiceServer } from '../models/voice-server';
@@ -86,5 +87,18 @@ export class ConfigurationController {
   async setVoiceServer(@Body(new ValidationPipe()) voiceServer: VoiceServer) {
     await this.configurationService.set(voiceServer);
     return await this.getVoiceServer();
+  }
+
+  @Get('discord')
+  @Auth(PlayerRole.admin)
+  async getDiscord() {
+    return await this.configurationService.getDiscord();
+  }
+
+  @Put('discord')
+  @Auth(PlayerRole.admin)
+  async setDiscord(@Body(new ValidationPipe()) discord: Discord) {
+    await this.configurationService.set(discord);
+    return await this.getDiscord();
   }
 }

--- a/src/configuration/models/configuration-entry-key.ts
+++ b/src/configuration/models/configuration-entry-key.ts
@@ -4,4 +4,5 @@ export enum ConfigurationEntryKey {
   etf2lAccountRequired = 'etf2l account required',
   minimumTf2InGameHours = 'minimum tf2 in-game hours',
   voiceServer = 'voice server',
+  discord = 'discord',
 }

--- a/src/configuration/models/discord.ts
+++ b/src/configuration/models/discord.ts
@@ -5,16 +5,28 @@ import { Equals } from 'class-validator';
 import { ConfigurationEntryKey } from './configuration-entry-key';
 
 @Schema()
-export class DiscordServerOptions {
+export class DiscordGuildOptions {
   @Prop({ required: true })
   guildId: string;
 
+  /**
+   * Where notifications for all the players are being sent.
+   * Set it to a falsy value to disable players notifications at all.
+   */
   @Prop()
   queueNotificationsChannelId?: string;
 
+  /**
+   * What role to mention in case there's a substitute needed.
+   * Set it to a falsy value to disable pinging any role.
+   */
   @Prop()
   substituteMentionRole?: string;
 
+  /**
+   * Where notifications for admins are being sent.
+   * Set it to a falsy value to disable admins notifications at all.
+   */
   @Prop()
   adminNotificationsChannelId?: string;
 
@@ -22,7 +34,8 @@ export class DiscordServerOptions {
   adminRole?: string;
 }
 
-const discordServerOptionsSchema = SchemaFactory.createForClass(DiscordServerOptions);
+const discordGuildOptionsSchema =
+  SchemaFactory.createForClass(DiscordGuildOptions);
 
 @Schema()
 export class Discord extends MongooseDocument {
@@ -34,9 +47,9 @@ export class Discord extends MongooseDocument {
   @Equals(ConfigurationEntryKey.discord)
   key: ConfigurationEntryKey.discord;
 
-  @Type(() => DiscordServerOptions)
-  @Prop({ type: [discordServerOptionsSchema], required: true, _id: false })
-  servers: DiscordServerOptions[];
+  @Type(() => DiscordGuildOptions)
+  @Prop({ type: [discordGuildOptionsSchema], required: true, _id: false })
+  guilds: DiscordGuildOptions[];
 }
 
 export const discordSchema = SchemaFactory.createForClass(Discord);

--- a/src/configuration/models/discord.ts
+++ b/src/configuration/models/discord.ts
@@ -1,0 +1,42 @@
+import { MongooseDocument } from '@/utils/mongoose-document';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Type } from 'class-transformer';
+import { Equals } from 'class-validator';
+import { ConfigurationEntryKey } from './configuration-entry-key';
+
+@Schema()
+export class DiscordServerOptions {
+  @Prop({ required: true })
+  guildId: string;
+
+  @Prop()
+  queueNotificationsChannelId?: string;
+
+  @Prop()
+  substituteMentionRole?: string;
+
+  @Prop()
+  adminNotificationsChannelId?: string;
+
+  @Prop()
+  adminRole?: string;
+}
+
+const discordServerOptionsSchema = SchemaFactory.createForClass(DiscordServerOptions);
+
+@Schema()
+export class Discord extends MongooseDocument {
+  constructor() {
+    super();
+    this.key = ConfigurationEntryKey.discord;
+  }
+
+  @Equals(ConfigurationEntryKey.discord)
+  key: ConfigurationEntryKey.discord;
+
+  @Type(() => DiscordServerOptions)
+  @Prop({ type: [discordServerOptionsSchema], required: true, _id: false })
+  servers: DiscordServerOptions[];
+}
+
+export const discordSchema = SchemaFactory.createForClass(Discord);

--- a/src/configuration/services/configuration.service.ts
+++ b/src/configuration/services/configuration.service.ts
@@ -8,6 +8,7 @@ import {
 } from '../models/configuration-entry';
 import { ConfigurationEntryKey } from '../models/configuration-entry-key';
 import { DefaultPlayerSkill } from '../models/default-player-skill';
+import { Discord } from '../models/discord';
 import { Etf2lAccountRequired } from '../models/etf2l-account-required';
 import { MinimumTf2InGameHours } from '../models/minimum-tf2-in-game-hours';
 import { VoiceServer } from '../models/voice-server';
@@ -63,6 +64,16 @@ export class ConfigurationService {
       await this.get(
         ConfigurationEntryKey.voiceServer,
         classToPlain(new VoiceServer()),
+      ),
+    );
+  }
+
+  async getDiscord(): Promise<Discord> {
+    return plainToClass(
+      Discord,
+      await this.get(
+        ConfigurationEntryKey.discord,
+        classToPlain(new Discord()),
       ),
     );
   }

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -106,28 +106,28 @@ export class PlayerSubstitutionService implements OnModuleInit {
     this.events.gameChanges.next({ game });
     this.events.substituteRequested.next({ gameId, playerId, adminId });
 
-    const channel = this.discordService?.getPlayersChannel();
-    if (channel) {
-      const embed = substituteRequest({
-        gameNumber: game.number,
-        gameClass: slot.gameClass,
-        team: slot.team.toUpperCase(),
-        gameUrl: `${this.environment.clientUrl}/game/${game.id}`,
-      });
+    // const channel = this.discordService?.getPlayersChannel();
+    // if (channel) {
+    //   const embed = substituteRequest({
+    //     gameNumber: game.number,
+    //     gameClass: slot.gameClass,
+    //     team: slot.team.toUpperCase(),
+    //     gameUrl: `${this.environment.clientUrl}/game/${game.id}`,
+    //   });
 
-      const roleToMention = this.discordService.findRole(
-        this.environment.discordQueueNotificationsMentionRole,
-      );
-      let message: Message;
+    //   const roleToMention = this.discordService.findRole(
+    //     this.environment.discordQueueNotificationsMentionRole,
+    //   );
+    //   let message: Message;
 
-      if (roleToMention?.mentionable) {
-        message = await channel.send(`${roleToMention}`, { embed });
-      } else {
-        message = await channel.send({ embed });
-      }
+    //   if (roleToMention?.mentionable) {
+    //     message = await channel.send(`${roleToMention}`, { embed });
+    //   } else {
+    //     message = await channel.send({ embed });
+    //   }
 
-      this.discordNotifications.set(playerId, message);
-    }
+    //   this.discordNotifications.set(playerId, message);
+    // }
 
     if (game.gameServer) {
       this.gameRuntimeService.sayChat(

--- a/src/plugins/discord/controllers/discord.controller.spec.ts
+++ b/src/plugins/discord/controllers/discord.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DiscordController } from './discord.controller';
+
+describe('DiscordController', () => {
+  let controller: DiscordController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DiscordController],
+    }).compile();
+
+    controller = module.get<DiscordController>(DiscordController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/plugins/discord/controllers/discord.controller.ts
+++ b/src/plugins/discord/controllers/discord.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { ChannelInfo } from '../dto/channel-info';
 import { GuildInfo } from '../dto/guild-info';
+import { RoleInfo } from '../dto/role-info';
 import { DiscordService } from '../services/discord.service';
 
 @Controller('discord')
@@ -27,5 +28,12 @@ export class DiscordController {
     return this.discordService
       .getTextChannelsForGuild(guildId)
       .map((c) => new ChannelInfo(c));
+  }
+
+  @Get('guilds/:guildId/roles')
+  getRoles(@Param('guildId') guildId: string): RoleInfo[] {
+    return this.discordService
+      .getRolesForGuild(guildId)
+      .map((r) => new RoleInfo(r));
   }
 }

--- a/src/plugins/discord/controllers/discord.controller.ts
+++ b/src/plugins/discord/controllers/discord.controller.ts
@@ -1,6 +1,12 @@
 import { Auth } from '@/auth/decorators/auth.decorator';
 import { PlayerRole } from '@/players/models/player-role';
-import { ClassSerializerInterceptor, Controller, Get, Param, UseInterceptors } from '@nestjs/common';
+import {
+  ClassSerializerInterceptor,
+  Controller,
+  Get,
+  Param,
+  UseInterceptors,
+} from '@nestjs/common';
 import { ChannelInfo } from '../dto/channel-info';
 import { GuildInfo } from '../dto/guild-info';
 import { DiscordService } from '../services/discord.service';
@@ -9,17 +15,17 @@ import { DiscordService } from '../services/discord.service';
 @UseInterceptors(ClassSerializerInterceptor)
 // @Auth(PlayerRole.admin)
 export class DiscordController {
-  constructor(
-    private discordService: DiscordService,
-  ) {}
+  constructor(private discordService: DiscordService) {}
 
   @Get('guilds')
   getGuilds(): GuildInfo[] {
-    return this.discordService.getAllGuilds().map(g => new GuildInfo(g));
+    return this.discordService.getAllGuilds().map((g) => new GuildInfo(g));
   }
 
   @Get('guilds/:guildId/text-channels')
   getTextChannels(@Param('guildId') guildId: string): ChannelInfo[] {
-    return this.discordService.getTextChannelsForGuild(guildId).map(c => new ChannelInfo(c));
+    return this.discordService
+      .getTextChannelsForGuild(guildId)
+      .map((c) => new ChannelInfo(c));
   }
 }

--- a/src/plugins/discord/controllers/discord.controller.ts
+++ b/src/plugins/discord/controllers/discord.controller.ts
@@ -1,0 +1,25 @@
+import { Auth } from '@/auth/decorators/auth.decorator';
+import { PlayerRole } from '@/players/models/player-role';
+import { ClassSerializerInterceptor, Controller, Get, Param, UseInterceptors } from '@nestjs/common';
+import { ChannelInfo } from '../dto/channel-info';
+import { GuildInfo } from '../dto/guild-info';
+import { DiscordService } from '../services/discord.service';
+
+@Controller('discord')
+@UseInterceptors(ClassSerializerInterceptor)
+// @Auth(PlayerRole.admin)
+export class DiscordController {
+  constructor(
+    private discordService: DiscordService,
+  ) {}
+
+  @Get('guilds')
+  getGuilds(): GuildInfo[] {
+    return this.discordService.getAllGuilds().map(g => new GuildInfo(g));
+  }
+
+  @Get('guilds/:guildId/text-channels')
+  getTextChannels(@Param('guildId') guildId: string): ChannelInfo[] {
+    return this.discordService.getTextChannelsForGuild(guildId).map(c => new ChannelInfo(c));
+  }
+}

--- a/src/plugins/discord/discord.module.ts
+++ b/src/plugins/discord/discord.module.ts
@@ -5,6 +5,8 @@ import { DiscordService } from './services/discord.service';
 import { QueuePromptsService } from './services/queue-prompts.service';
 import { AdminNotificationsService } from './services/admin-notifications.service';
 import { GamesModule } from '@/games/games.module';
+import { DiscordController } from './controllers/discord.controller';
+import { ConfigurationModule } from '@/configuration/configuration.module';
 
 @Global()
 @Module({
@@ -12,8 +14,10 @@ import { GamesModule } from '@/games/games.module';
     forwardRef(() => QueueModule),
     forwardRef(() => PlayersModule),
     GamesModule,
+    ConfigurationModule,
   ],
   providers: [DiscordService, QueuePromptsService, AdminNotificationsService],
   exports: [DiscordService],
+  controllers: [DiscordController],
 })
 export class DiscordModule {}

--- a/src/plugins/discord/dto/channel-info.ts
+++ b/src/plugins/discord/dto/channel-info.ts
@@ -1,10 +1,10 @@
-import { GuildChannel } from "discord.js";
+import { GuildChannel } from 'discord.js';
 
 export class ChannelInfo {
   constructor(channel: GuildChannel) {
     this.id = channel.id;
     this.name = channel.name;
-    this.position = channel.position;
+    this.position = channel.rawPosition;
   }
 
   id: string;

--- a/src/plugins/discord/dto/channel-info.ts
+++ b/src/plugins/discord/dto/channel-info.ts
@@ -4,8 +4,10 @@ export class ChannelInfo {
   constructor(channel: GuildChannel) {
     this.id = channel.id;
     this.name = channel.name;
+    this.position = channel.position;
   }
 
   id: string;
   name: string;
+  position: number;
 }

--- a/src/plugins/discord/dto/channel-info.ts
+++ b/src/plugins/discord/dto/channel-info.ts
@@ -1,0 +1,11 @@
+import { GuildChannel } from "discord.js";
+
+export class ChannelInfo {
+  constructor(channel: GuildChannel) {
+    this.id = channel.id;
+    this.name = channel.name;
+  }
+
+  id: string;
+  name: string;
+}

--- a/src/plugins/discord/dto/guild-info.ts
+++ b/src/plugins/discord/dto/guild-info.ts
@@ -1,0 +1,13 @@
+import { Guild } from "discord.js";
+
+export class GuildInfo {
+  constructor(guild: Guild) {
+    this.id = guild.id;
+    this.name = guild.name;
+    this.icon = guild.iconURL({ format: 'webp' });
+  }
+
+  id: string;
+  name: string;
+  icon: string;
+}

--- a/src/plugins/discord/dto/guild-info.ts
+++ b/src/plugins/discord/dto/guild-info.ts
@@ -1,10 +1,10 @@
-import { Guild } from "discord.js";
+import { Guild } from 'discord.js';
 
 export class GuildInfo {
   constructor(guild: Guild) {
     this.id = guild.id;
     this.name = guild.name;
-    this.icon = guild.iconURL({ format: 'webp' });
+    this.icon = guild.iconURL({ format: 'webp', dynamic: false });
   }
 
   id: string;

--- a/src/plugins/discord/dto/role-info.ts
+++ b/src/plugins/discord/dto/role-info.ts
@@ -1,0 +1,13 @@
+import { Role } from 'discord.js';
+
+export class RoleInfo {
+  constructor(role: Role) {
+    this.id = role.id;
+    this.name = role.name;
+    this.position = role.position;
+  }
+
+  id: string;
+  name: string;
+  position: number;
+}

--- a/src/plugins/discord/services/admin-notifications.service.ts
+++ b/src/plugins/discord/services/admin-notifications.service.ts
@@ -113,12 +113,12 @@ export class AdminNotificationsService implements OnModuleInit {
   }
 
   private onPlayerRegisters(player: Player) {
-    this.discordService.getAdminsChannel()?.send({
-      embed: newPlayer({
-        name: player.name,
-        profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: newPlayer({
+    //     name: player.name,
+    //     profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+    //   }),
+    // });
   }
 
   private async onPlayerUpdates(
@@ -148,76 +148,76 @@ export class AdminNotificationsService implements OnModuleInit {
       return; // skip empty notification
     }
 
-    this.discordService.getAdminsChannel()?.send({
-      embed: playerProfileUpdated({
-        player: {
-          name: oldPlayer.name,
-          profileUrl: `${this.environment.clientUrl}/player/${oldPlayer.id}`,
-          avatarUrl: newPlayer.avatar?.medium,
-        },
-        admin: {
-          name: admin.name,
-          profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-          avatarUrl: admin.avatar?.small,
-        },
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-        changes,
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: playerProfileUpdated({
+    //     player: {
+    //       name: oldPlayer.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${oldPlayer.id}`,
+    //       avatarUrl: newPlayer.avatar?.medium,
+    //     },
+    //     admin: {
+    //       name: admin.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+    //       avatarUrl: admin.avatar?.small,
+    //     },
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //     changes,
+    //   }),
+    // });
   }
 
   private async onPlayerBanAdded(ban: PlayerBan) {
     const admin = await this.playersService.getById(ban.admin);
     const player = await this.playersService.getById(ban.player);
 
-    this.discordService.getAdminsChannel()?.send({
-      embed: playerBanAdded({
-        admin: {
-          name: admin.name,
-          profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-          avatarUrl: admin.avatar?.small,
-        },
-        player: {
-          name: player.name,
-          profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-          avatarUrl: player.avatar?.medium,
-        },
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-        reason: ban.reason,
-        ends: ban.end,
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: playerBanAdded({
+    //     admin: {
+    //       name: admin.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+    //       avatarUrl: admin.avatar?.small,
+    //     },
+    //     player: {
+    //       name: player.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+    //       avatarUrl: player.avatar?.medium,
+    //     },
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //     reason: ban.reason,
+    //     ends: ban.end,
+    //   }),
+    // });
   }
 
   private async onPlayerBanRevoked(ban: PlayerBan, adminId: string) {
     const admin = await this.playersService.getById(adminId);
     const player = await this.playersService.getById(ban.player);
 
-    this.discordService.getAdminsChannel()?.send({
-      embed: playerBanRevoked({
-        admin: {
-          name: admin.name,
-          profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-          avatarUrl: admin.avatar?.small,
-        },
-        player: {
-          name: player.name,
-          profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-          avatarUrl: player.avatar?.medium,
-        },
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-        reason: ban.reason,
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: playerBanRevoked({
+    //     admin: {
+    //       name: admin.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+    //       avatarUrl: admin.avatar?.small,
+    //     },
+    //     player: {
+    //       name: player.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+    //       avatarUrl: player.avatar?.medium,
+    //     },
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //     reason: ban.reason,
+    //   }),
+    // });
   }
 
   private async onPlayerSkillChanged(
@@ -237,62 +237,62 @@ export class AdminNotificationsService implements OnModuleInit {
     const player = await this.playersService.getById(playerId);
     const admin = await this.playersService.getById(adminId);
 
-    this.discordService.getAdminsChannel()?.send({
-      embed: playerSkillChanged({
-        admin: {
-          name: admin.name,
-          profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-          avatarUrl: admin.avatar?.small,
-        },
-        player: {
-          name: player.name,
-          profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-          avatarUrl: player.avatar?.medium,
-        },
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-        oldSkill,
-        newSkill,
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: playerSkillChanged({
+    //     admin: {
+    //       name: admin.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+    //       avatarUrl: admin.avatar?.small,
+    //     },
+    //     player: {
+    //       name: player.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+    //       avatarUrl: player.avatar?.medium,
+    //     },
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //     oldSkill,
+    //     newSkill,
+    //   }),
+    // });
   }
 
   private async onGameServerAdded(gameServer: GameServer) {
-    this.discordService.getAdminsChannel()?.send({
-      embed: gameServerAdded({
-        gameServer,
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: gameServerAdded({
+    //     gameServer,
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //   }),
+    // });
   }
 
   private async onGameServerWentOffline(gameServer: GameServer) {
-    this.discordService.getAdminsChannel()?.send({
-      embed: gameServerOffline({
-        gameServer,
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: gameServerOffline({
+    //     gameServer,
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //   }),
+    // });
   }
 
   private async onGameServerBackOnline(gameServer: GameServer) {
-    this.discordService.getAdminsChannel()?.send({
-      embed: gameServerOnline({
-        gameServer,
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: gameServerOnline({
+    //     gameServer,
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //   }),
+    // });
   }
 
   private async onGameForceEnded(game: Game, adminId: string) {
@@ -301,23 +301,23 @@ export class AdminNotificationsService implements OnModuleInit {
     }
 
     const admin = await this.playersService.getById(adminId);
-    this.discordService.getAdminsChannel()?.send({
-      embed: gameForceEnded({
-        admin: {
-          name: admin.name,
-          profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-          avatarUrl: admin.avatar?.small,
-        },
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-        game: {
-          number: `${game.number}`,
-          url: `${this.environment.clientUrl}/game/${game.id}`,
-        },
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: gameForceEnded({
+    //     admin: {
+    //       name: admin.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+    //       avatarUrl: admin.avatar?.small,
+    //     },
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //     game: {
+    //       number: `${game.number}`,
+    //       url: `${this.environment.clientUrl}/game/${game.id}`,
+    //     },
+    //   }),
+    // });
   }
 
   private async onSubstituteRequested(
@@ -329,26 +329,26 @@ export class AdminNotificationsService implements OnModuleInit {
     const player = await this.playersService.getById(playerId);
     const game = await this.gamesService.getById(gameId);
 
-    this.discordService.getAdminsChannel()?.send({
-      embed: substituteRequested({
-        player: {
-          name: player.name,
-          profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-        },
-        admin: {
-          name: admin.name,
-          profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-          avatarUrl: admin.avatar?.small,
-        },
-        game: {
-          number: `${game.number}`,
-          url: `${this.environment.clientUrl}/game/${game.id}`,
-        },
-        client: {
-          name: new URL(this.environment.clientUrl).hostname,
-          iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-        },
-      }),
-    });
+    // this.discordService.getAdminsChannel()?.send({
+    //   embed: substituteRequested({
+    //     player: {
+    //       name: player.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+    //     },
+    //     admin: {
+    //       name: admin.name,
+    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+    //       avatarUrl: admin.avatar?.small,
+    //     },
+    //     game: {
+    //       number: `${game.number}`,
+    //       url: `${this.environment.clientUrl}/game/${game.id}`,
+    //     },
+    //     client: {
+    //       name: new URL(this.environment.clientUrl).hostname,
+    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //     },
+    //   }),
+    // });
   }
 }

--- a/src/plugins/discord/services/admin-notifications.service.ts
+++ b/src/plugins/discord/services/admin-notifications.service.ts
@@ -112,13 +112,18 @@ export class AdminNotificationsService implements OnModuleInit {
       );
   }
 
-  private onPlayerRegisters(player: Player) {
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: newPlayer({
-    //     name: player.name,
-    //     profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-    //   }),
-    // });
+  private async onPlayerRegisters(player: Player) {
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: newPlayer({
+              name: player.name,
+              profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+            }),
+          }),
+      ),
+    );
   }
 
   private async onPlayerUpdates(
@@ -148,76 +153,91 @@ export class AdminNotificationsService implements OnModuleInit {
       return; // skip empty notification
     }
 
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: playerProfileUpdated({
-    //     player: {
-    //       name: oldPlayer.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${oldPlayer.id}`,
-    //       avatarUrl: newPlayer.avatar?.medium,
-    //     },
-    //     admin: {
-    //       name: admin.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-    //       avatarUrl: admin.avatar?.small,
-    //     },
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //     changes,
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: playerProfileUpdated({
+              player: {
+                name: oldPlayer.name,
+                profileUrl: `${this.environment.clientUrl}/player/${oldPlayer.id}`,
+                avatarUrl: newPlayer.avatar?.medium,
+              },
+              admin: {
+                name: admin.name,
+                profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+                avatarUrl: admin.avatar?.small,
+              },
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+              changes,
+            }),
+          }),
+      ),
+    );
   }
 
   private async onPlayerBanAdded(ban: PlayerBan) {
     const admin = await this.playersService.getById(ban.admin);
     const player = await this.playersService.getById(ban.player);
 
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: playerBanAdded({
-    //     admin: {
-    //       name: admin.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-    //       avatarUrl: admin.avatar?.small,
-    //     },
-    //     player: {
-    //       name: player.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-    //       avatarUrl: player.avatar?.medium,
-    //     },
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //     reason: ban.reason,
-    //     ends: ban.end,
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: playerBanAdded({
+              admin: {
+                name: admin.name,
+                profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+                avatarUrl: admin.avatar?.small,
+              },
+              player: {
+                name: player.name,
+                profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+                avatarUrl: player.avatar?.medium,
+              },
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+              reason: ban.reason,
+              ends: ban.end,
+            }),
+          }),
+      ),
+    );
   }
 
   private async onPlayerBanRevoked(ban: PlayerBan, adminId: string) {
     const admin = await this.playersService.getById(adminId);
     const player = await this.playersService.getById(ban.player);
 
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: playerBanRevoked({
-    //     admin: {
-    //       name: admin.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-    //       avatarUrl: admin.avatar?.small,
-    //     },
-    //     player: {
-    //       name: player.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-    //       avatarUrl: player.avatar?.medium,
-    //     },
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //     reason: ban.reason,
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: playerBanRevoked({
+              admin: {
+                name: admin.name,
+                profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+                avatarUrl: admin.avatar?.small,
+              },
+              player: {
+                name: player.name,
+                profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+                avatarUrl: player.avatar?.medium,
+              },
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+              reason: ban.reason,
+            }),
+          }),
+      ),
+    );
   }
 
   private async onPlayerSkillChanged(
@@ -237,62 +257,82 @@ export class AdminNotificationsService implements OnModuleInit {
     const player = await this.playersService.getById(playerId);
     const admin = await this.playersService.getById(adminId);
 
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: playerSkillChanged({
-    //     admin: {
-    //       name: admin.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-    //       avatarUrl: admin.avatar?.small,
-    //     },
-    //     player: {
-    //       name: player.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-    //       avatarUrl: player.avatar?.medium,
-    //     },
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //     oldSkill,
-    //     newSkill,
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: playerSkillChanged({
+              admin: {
+                name: admin.name,
+                profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+                avatarUrl: admin.avatar?.small,
+              },
+              player: {
+                name: player.name,
+                profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+                avatarUrl: player.avatar?.medium,
+              },
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+              oldSkill,
+              newSkill,
+            }),
+          }),
+      ),
+    );
   }
 
   private async onGameServerAdded(gameServer: GameServer) {
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: gameServerAdded({
-    //     gameServer,
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: gameServerAdded({
+              gameServer,
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+            }),
+          }),
+      ),
+    );
   }
 
   private async onGameServerWentOffline(gameServer: GameServer) {
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: gameServerOffline({
-    //     gameServer,
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: gameServerOffline({
+              gameServer,
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+            }),
+          }),
+      ),
+    );
   }
 
   private async onGameServerBackOnline(gameServer: GameServer) {
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: gameServerOnline({
-    //     gameServer,
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: gameServerOnline({
+              gameServer,
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+            }),
+          }),
+      ),
+    );
   }
 
   private async onGameForceEnded(game: Game, adminId: string) {
@@ -301,23 +341,28 @@ export class AdminNotificationsService implements OnModuleInit {
     }
 
     const admin = await this.playersService.getById(adminId);
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: gameForceEnded({
-    //     admin: {
-    //       name: admin.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-    //       avatarUrl: admin.avatar?.small,
-    //     },
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //     game: {
-    //       number: `${game.number}`,
-    //       url: `${this.environment.clientUrl}/game/${game.id}`,
-    //     },
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: gameForceEnded({
+              admin: {
+                name: admin.name,
+                profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+                avatarUrl: admin.avatar?.small,
+              },
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+              game: {
+                number: `${game.number}`,
+                url: `${this.environment.clientUrl}/game/${game.id}`,
+              },
+            }),
+          }),
+      ),
+    );
   }
 
   private async onSubstituteRequested(
@@ -329,26 +374,31 @@ export class AdminNotificationsService implements OnModuleInit {
     const player = await this.playersService.getById(playerId);
     const game = await this.gamesService.getById(gameId);
 
-    // this.discordService.getAdminsChannel()?.send({
-    //   embed: substituteRequested({
-    //     player: {
-    //       name: player.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
-    //     },
-    //     admin: {
-    //       name: admin.name,
-    //       profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
-    //       avatarUrl: admin.avatar?.small,
-    //     },
-    //     game: {
-    //       number: `${game.number}`,
-    //       url: `${this.environment.clientUrl}/game/${game.id}`,
-    //     },
-    //     client: {
-    //       name: new URL(this.environment.clientUrl).hostname,
-    //       iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-    //     },
-    //   }),
-    // });
+    return Promise.all(
+      (await this.discordService.getAdminsChannels()).map(
+        async (channel) =>
+          await channel.send({
+            embed: substituteRequested({
+              player: {
+                name: player.name,
+                profileUrl: `${this.environment.clientUrl}/player/${player.id}`,
+              },
+              admin: {
+                name: admin.name,
+                profileUrl: `${this.environment.clientUrl}/player/${admin.id}`,
+                avatarUrl: admin.avatar?.small,
+              },
+              game: {
+                number: `${game.number}`,
+                url: `${this.environment.clientUrl}/game/${game.id}`,
+              },
+              client: {
+                name: new URL(this.environment.clientUrl).hostname,
+                iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+              },
+            }),
+          }),
+      ),
+    );
   }
 }

--- a/src/plugins/discord/services/discord.service.ts
+++ b/src/plugins/discord/services/discord.service.ts
@@ -52,6 +52,10 @@ export class DiscordService implements OnModuleInit {
     return this.getAllGuilds().filter((guild) => guildIds.includes(guild.id));
   }
 
+  getGuild(guildId: string): Guild {
+    return this.client.guilds.cache.get(guildId);
+  }
+
   /**
    * Get channels for admins' notifications for all enabled guilds.
    */
@@ -59,7 +63,7 @@ export class DiscordService implements OnModuleInit {
     return (await this.configurationService.getDiscord()).guilds
       .map((server) => {
         if (server.adminNotificationsChannelId) {
-          const guild = this.client.guilds.cache.get(server.guildId);
+          const guild = this.getGuild(server.guildId);
           return guild.channels.cache
             .filter((c) => c.isText())
             .find(

--- a/src/plugins/discord/services/discord.service.ts
+++ b/src/plugins/discord/services/discord.service.ts
@@ -31,12 +31,19 @@ export class DiscordService implements OnModuleInit {
 
   getTextChannelsForGuild(guildId: string): TextChannel[] {
     const guild = this.client.guilds.cache.get(guildId);
-    return Array.from(guild.channels.cache.filter(c => c.isText()).values()) as TextChannel[];
+    return Array.from(
+      guild.channels.cache
+        .filter((c) => c.isText())
+        .filter((c) => !c.deleted)
+        .values(),
+    ) as TextChannel[];
   }
 
   async getEnabledGuilds(): Promise<Guild[]> {
-    const guildIds = (await this.configurationService.getDiscord()).servers.map(server => server.guildId);
-    return this.getAllGuilds().filter(guild => guildIds.includes(guild.id));
+    const guildIds = (await this.configurationService.getDiscord()).servers.map(
+      (server) => server.guildId,
+    );
+    return this.getAllGuilds().filter((guild) => guildIds.includes(guild.id));
   }
 
   /**
@@ -44,17 +51,19 @@ export class DiscordService implements OnModuleInit {
    */
   async getAdminsChannels(): Promise<TextChannel[]> {
     return (await this.configurationService.getDiscord()).servers
-      .map(server => {
+      .map((server) => {
         if (server.adminNotificationsChannelId) {
           const guild = this.client.guilds.cache.get(server.guildId);
           return guild.channels.cache
-            .filter(c => c.isText())
-            .find(c => c.id === server.adminNotificationsChannelId) as TextChannel;
+            .filter((c) => c.isText())
+            .find(
+              (c) => c.id === server.adminNotificationsChannelId,
+            ) as TextChannel;
         } else {
           return null;
         }
       })
-      .filter(c => c !== null);
+      .filter((c) => c !== null);
   }
 
   /**
@@ -62,16 +71,18 @@ export class DiscordService implements OnModuleInit {
    */
   async getQueueNotificationsChannels(): Promise<TextChannel[]> {
     return (await this.configurationService.getDiscord()).servers
-      .map(server => {
+      .map((server) => {
         if (server.queueNotificationsChannelId) {
           const guild = this.client.guilds.cache.get(server.guildId);
           return guild.channels.cache
-            .filter(c => c.isText())
-            .find(c => c.id === server.queueNotificationsChannelId) as TextChannel;
+            .filter((c) => c.isText())
+            .find(
+              (c) => c.id === server.queueNotificationsChannelId,
+            ) as TextChannel;
         } else {
           return null;
         }
       })
-      .filter(c => c !== null);
+      .filter((c) => c !== null);
   }
 }

--- a/src/plugins/discord/services/queue-prompts.service.ts
+++ b/src/plugins/discord/services/queue-prompts.service.ts
@@ -50,10 +50,10 @@ export class QueuePromptsService implements OnModuleInit {
     //   this.message.edit({ embed });
     // } else {
     //   if (this.playerThresholdMet()) {
-        // this.message = await this.discordService
-        //   .getPlayersChannel()
-        //   ?.send({ embed });
-      // }
+    //     this.message = await this.discordService
+    //       .getPlayersChannel()
+    //       ?.send({ embed });
+    //   }
     // }
   }
 

--- a/src/plugins/discord/services/queue-prompts.service.ts
+++ b/src/plugins/discord/services/queue-prompts.service.ts
@@ -37,24 +37,24 @@ export class QueuePromptsService implements OnModuleInit {
     this.requiredPlayerCount = slots.length;
     const clientName = new URL(this.environment.clientUrl).hostname;
 
-    const embed = queuePreview({
-      iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
-      clientName,
-      clientUrl: this.environment.clientUrl,
-      playerCount: this.queueService.playerCount,
-      requiredPlayerCount: this.queueService.requiredPlayerCount,
-      gameClassData: await this.slotsToGameClassData(slots),
-    });
+    // const embed = queuePreview({
+    //   iconUrl: `${this.environment.clientUrl}/${iconUrlPath}`,
+    //   clientName,
+    //   clientUrl: this.environment.clientUrl,
+    //   playerCount: this.queueService.playerCount,
+    //   requiredPlayerCount: this.queueService.requiredPlayerCount,
+    //   gameClassData: await this.slotsToGameClassData(slots),
+    // });
 
-    if (this.message) {
-      this.message.edit({ embed });
-    } else {
-      if (this.playerThresholdMet()) {
-        this.message = await this.discordService
-          .getPlayersChannel()
-          ?.send({ embed });
-      }
-    }
+    // if (this.message) {
+    //   this.message.edit({ embed });
+    // } else {
+    //   if (this.playerThresholdMet()) {
+        // this.message = await this.discordService
+        //   .getPlayersChannel()
+        //   ?.send({ embed });
+      // }
+    // }
   }
 
   private async slotsToGameClassData(slots: QueueSlot[]) {
@@ -71,7 +71,7 @@ export class QueuePromptsService implements OnModuleInit {
 
     return this.queueConfigService.queueConfig.classes.map((gameClass) => ({
       gameClass: gameClass.name,
-      emoji: this.discordService.findEmoji(`tf2${gameClass.name}`),
+      // emoji: this.discordService.findEmoji(`tf2${gameClass.name}`),
       playersRequired:
         gameClass.count * this.queueConfigService.queueConfig.teamCount,
       players: playerData.filter((p) => p.gameClass === gameClass.name),
@@ -87,16 +87,16 @@ export class QueuePromptsService implements OnModuleInit {
 
   @Cron(CronExpression.EVERY_5_MINUTES)
   async ensurePromptIsVisible() {
-    const messages = await this.discordService
-      .getPlayersChannel()
-      .messages.fetch({ limit: 1 });
-    if (
-      messages?.first()?.id !== this.message?.id &&
-      this.playerThresholdMet()
-    ) {
-      await this.message?.delete();
-      delete this.message;
-      this.refreshPrompt(this.queueService.slots);
-    }
+    // const messages = await this.discordService
+    //   .getPlayersChannel()
+    //   .messages.fetch({ limit: 1 });
+    // if (
+    //   messages?.first()?.id !== this.message?.id &&
+    //   this.playerThresholdMet()
+    // ) {
+    //   await this.message?.delete();
+    //   delete this.message;
+    //   this.refreshPrompt(this.queueService.slots);
+    // }
   }
 }


### PR DESCRIPTION
Make the Discord bot configurable via the ConfigurationModule API and remove the necessity to configure it via the .env file. Add the support for multiple guilds.

Make the following env variables obsolete:
 * `DISCORD_GUILD`
 * `DISCORD_QUEUE_NOTIFICATIONS_CHANNEL`
 * `DISCORD_QUEUE_NOTIFICATIONS_MENTION_ROLE`
 * `DISCORD_ADMIN_NOTIFICATIONS_CHANNEL`