### PR TITLE
feat(players): accept SteamId

### DIFF
--- a/src/players/controllers/players.controller.spec.ts
+++ b/src/players/controllers/players.controller.spec.ts
@@ -186,28 +186,9 @@ describe('Players Controller', () => {
   });
 
   describe('#getPlayer()', () => {
-    describe('when looking up by object id', () => {
-      it('should return the player', async () => {
-        const spy = jest.spyOn(playersService, 'getById');
-        const ret = await controller.getPlayer({
-          type: 'object-id',
-          objectId: 'FAKE_ID',
-        });
-        expect(spy).toHaveBeenCalledWith('FAKE_ID');
-        expect(ret).toEqual(playersService.player as any);
-      });
-    });
-
-    describe('when looking up by steam id', () => {
-      it('should return the player', async () => {
-        const spy = jest.spyOn(playersService, 'findBySteamId');
-        const ret = await controller.getPlayer({
-          type: 'steam-id',
-          steamId64: '76561198074409147',
-        });
-        expect(spy).toHaveBeenCalledWith('76561198074409147');
-        expect(ret).toEqual(playersService.player);
-      });
+    it('should return the player', async () => {
+      const ret = await controller.getPlayer(playersService.player);
+      expect(ret).toEqual(playersService.player as any);
     });
   });
 
@@ -231,7 +212,7 @@ describe('Players Controller', () => {
     it('should update the player', async () => {
       const spy = jest.spyOn(playersService, 'updatePlayer');
       const ret = await controller.updatePlayer(
-        'FAKE_ID',
+        playersService.player,
         { name: 'FAKE_NEW_NAME' },
         { id: 'FAKE_ADMIN_ID' } as any,
       );
@@ -250,7 +231,7 @@ describe('Players Controller', () => {
       const spy2 = jest.spyOn(gamesService, 'getPlayerGameCount');
 
       const ret = await controller.getPlayerGames(
-        'FAKE_ID',
+        playersService.player,
         44,
         52,
         'launched_at',
@@ -265,7 +246,7 @@ describe('Players Controller', () => {
 
     it('should throw an error unless the sort param is correct', async () => {
       await expect(
-        controller.getPlayerGames('FAKE_ID', 3, 5, 'lol'),
+        controller.getPlayerGames(playersService.player, 3, 5, 'lol'),
       ).rejects.toThrow();
     });
   });
@@ -273,7 +254,7 @@ describe('Players Controller', () => {
   describe('#getPlayerStats()', () => {
     it('should return player stats', async () => {
       const spy = jest.spyOn(playersService, 'getPlayerStats');
-      const ret = await controller.getPlayerStats('FAKE_ID');
+      const ret = await controller.getPlayerStats(playersService.player);
       expect(spy).toHaveBeenCalledWith('FAKE_ID');
       expect(ret).toEqual(playersService.stats);
     });
@@ -291,16 +272,16 @@ describe('Players Controller', () => {
   describe('#getPlayerSkill()', () => {
     it('should return player skill', async () => {
       const spy = jest.spyOn(playerSkillService, 'getPlayerSkill');
-      const ret = await controller.getPlayerSkill('FAKE_ID');
+      const ret = await controller.getPlayerSkill(playersService.player);
       expect(spy).toHaveBeenCalledWith('FAKE_ID');
       expect(ret).toEqual(playerSkillService.skill);
     });
 
     it('should return 404', async () => {
       jest.spyOn(playerSkillService, 'getPlayerSkill').mockResolvedValue(null);
-      await expect(controller.getPlayerSkill('FAKE_ID')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        controller.getPlayerSkill(playersService.player),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -308,9 +289,13 @@ describe('Players Controller', () => {
     it('should set player skill', async () => {
       const skill = { soldier: 1, medic: 2 };
       const spy = jest.spyOn(playerSkillService, 'setPlayerSkill');
-      const ret = await controller.setPlayerSkill('FAKE_ID', skill, {
-        id: 'FAKE_ADMIN_ID',
-      } as any);
+      const ret = await controller.setPlayerSkill(
+        playersService.player,
+        skill,
+        {
+          id: 'FAKE_ADMIN_ID',
+        } as any,
+      );
       expect(spy).toHaveBeenCalledWith(
         'FAKE_ID',
         new Map([
@@ -326,7 +311,7 @@ describe('Players Controller', () => {
   describe('#getPlayerBans()', () => {
     it('should return player bans', async () => {
       const spy = jest.spyOn(playerBansService, 'getPlayerBans');
-      const ret = await controller.getPlayerBans('FAKE_ID');
+      const ret = await controller.getPlayerBans(playersService.player);
       expect(spy).toHaveBeenCalledWith('FAKE_ID');
       expect(ret).toEqual(playerBansService.bans as any);
     });
@@ -377,13 +362,13 @@ describe('Players Controller', () => {
     });
 
     it('should query the service', async () => {
-      const result = await controller.getPlayerLinkedProfiles('FAKE_PLAYER_ID');
+      const result = await controller.getPlayerLinkedProfiles(
+        playersService.player,
+      );
       expect(linkedProfilesService.getLinkedProfiles).toHaveBeenCalledWith(
-        'FAKE_PLAYER_ID',
+        'FAKE_ID',
       );
-      expect(result).toEqual(
-        new LinkedProfiles('FAKE_PLAYER_ID', linkedProfiles),
-      );
+      expect(result).toEqual(new LinkedProfiles('FAKE_ID', linkedProfiles));
     });
   });
 });

--- a/src/players/controllers/players.controller.spec.ts
+++ b/src/players/controllers/players.controller.spec.ts
@@ -46,6 +46,9 @@ class PlayersServiceStub {
   getById(id: string) {
     return new Promise((resolve) => resolve(this.player));
   }
+  findBySteamId(steamId: string) {
+    return new Promise((resolve) => resolve(this.player));
+  }
   forceCreatePlayer(player: Player) {
     return new Promise((resolve) => resolve(player));
   }
@@ -183,11 +186,28 @@ describe('Players Controller', () => {
   });
 
   describe('#getPlayer()', () => {
-    it('should return the player', async () => {
-      const spy = jest.spyOn(playersService, 'getById');
-      const ret = await controller.getPlayer('FAKE_ID');
-      expect(spy).toHaveBeenCalledWith('FAKE_ID');
-      expect(ret).toEqual(playersService.player as any);
+    describe('when looking up by object id', () => {
+      it('should return the player', async () => {
+        const spy = jest.spyOn(playersService, 'getById');
+        const ret = await controller.getPlayer({
+          type: 'object-id',
+          objectId: 'FAKE_ID',
+        });
+        expect(spy).toHaveBeenCalledWith('FAKE_ID');
+        expect(ret).toEqual(playersService.player as any);
+      });
+    });
+
+    describe('when looking up by steam id', () => {
+      it('should return the player', async () => {
+        const spy = jest.spyOn(playersService, 'findBySteamId');
+        const ret = await controller.getPlayer({
+          type: 'steam-id',
+          steamId64: '76561198074409147',
+        });
+        expect(spy).toHaveBeenCalledWith('76561198074409147');
+        expect(ret).toEqual(playersService.player);
+      });
     });
   });
 

--- a/src/players/controllers/players.controller.ts
+++ b/src/players/controllers/players.controller.ts
@@ -18,7 +18,6 @@ import {
   CacheInterceptor,
   CacheTTL,
   ClassSerializerInterceptor,
-  UseFilters,
 } from '@nestjs/common';
 import { PlayersService } from '../services/players.service';
 import { ObjectIdValidationPipe } from '@/shared/pipes/object-id-validation.pipe';
@@ -30,14 +29,12 @@ import { PlayerBansService } from '../services/player-bans.service';
 import { PlayerBan } from '../models/player-ban';
 import { User } from '@/auth/decorators/user.decorator';
 import { Tf2ClassName } from '@/shared/models/tf2-class-name';
-import { DocumentNotFoundFilter } from '@/shared/filters/document-not-found.filter';
 import { PlayerStats } from '../dto/player-stats';
 import { ForceCreatePlayer } from '../dto/force-create-player';
 import { PlayerRole } from '../models/player-role';
 import { LinkedProfilesService } from '../services/linked-profiles.service';
 import { LinkedProfiles } from '../dto/linked-profiles';
-import { ObjectIdOrSteamIdPipe } from '@/shared/pipes/object-id-or-steam-id.pipe';
-import { ObjectIdOrSteamId } from '@/shared/models/object-id-or-steam-id';
+import { PlayerByIdPipe } from '../pipes/player-by-id.pipe';
 
 @Controller('players')
 @UseInterceptors(CacheInterceptor)
@@ -58,17 +55,8 @@ export class PlayersController {
 
   @Get(':id')
   @UseInterceptors(ClassSerializerInterceptor)
-  @UseFilters(DocumentNotFoundFilter)
-  async getPlayer(
-    @Param('id', ObjectIdOrSteamIdPipe) playerId: ObjectIdOrSteamId,
-  ) {
-    switch (playerId.type) {
-      case 'object-id':
-        return this.playersService.getById(playerId.objectId);
-
-      case 'steam-id':
-        return this.playersService.findBySteamId(playerId.steamId64);
-    }
+  async getPlayer(@Param('id', PlayerByIdPipe) player: Player) {
+    return player;
   }
 
   @Post()
@@ -83,17 +71,17 @@ export class PlayersController {
   @Auth(PlayerRole.admin)
   @UseInterceptors(ClassSerializerInterceptor)
   async updatePlayer(
-    @Param('id', ObjectIdValidationPipe) playerId: string,
-    @Body() player: Partial<Player>,
+    @Param('id', PlayerByIdPipe) player: Player,
+    @Body() update: Partial<Player>,
     @User() admin: Player,
   ) {
-    return await this.playersService.updatePlayer(playerId, player, admin.id);
+    return await this.playersService.updatePlayer(player.id, update, admin.id);
   }
 
   @Get(':id/games')
   @Header('Warning', '299 - "Deprecated API"')
   async getPlayerGames(
-    @Param('id', ObjectIdValidationPipe) playerId: string,
+    @Param('id', PlayerByIdPipe) player: Player,
     @Query('limit', ParseIntPipe) limit = 10,
     @Query('offset', ParseIntPipe) offset = 0,
     @Query('sort') sort = '-launched_at',
@@ -115,8 +103,8 @@ export class PlayersController {
     }
 
     const [results, itemCount] = await Promise.all([
-      this.gamesService.getPlayerGames(playerId, sortParam, limit, offset),
-      this.gamesService.getPlayerGameCount(playerId),
+      this.gamesService.getPlayerGames(player.id, sortParam, limit, offset),
+      this.gamesService.getPlayerGameCount(player.id),
     ]);
 
     return { results, itemCount };
@@ -126,9 +114,9 @@ export class PlayersController {
   @Get(':id/stats')
   @UseInterceptors(ClassSerializerInterceptor)
   async getPlayerStats(
-    @Param('id', ObjectIdValidationPipe) playerId: string,
+    @Param('id', PlayerByIdPipe) player: Player,
   ): Promise<PlayerStats> {
-    return await this.playersService.getPlayerStats(playerId);
+    return await this.playersService.getPlayerStats(player.id);
   }
 
   @Get('/all/skill')
@@ -139,8 +127,8 @@ export class PlayersController {
 
   @Get(':id/skill')
   @Auth(PlayerRole.admin)
-  async getPlayerSkill(@Param('id', ObjectIdValidationPipe) playerId: string) {
-    const skill = await this.playerSkillService.getPlayerSkill(playerId);
+  async getPlayerSkill(@Param('id', PlayerByIdPipe) player: Player) {
+    const skill = await this.playerSkillService.getPlayerSkill(player.id);
     if (skill) {
       return skill;
     } else {
@@ -152,7 +140,7 @@ export class PlayersController {
   @Auth(PlayerRole.admin)
   // todo validate skill
   async setPlayerSkill(
-    @Param('id', ObjectIdValidationPipe) playerId: string,
+    @Param('id', PlayerByIdPipe) player: Player,
     @Body() newSkill: { [className in Tf2ClassName]?: number },
     @User() user: Player,
   ) {
@@ -161,7 +149,7 @@ export class PlayersController {
       number
     >;
     return this.playerSkillService.setPlayerSkill(
-      playerId,
+      player.id,
       newSkillAsMap,
       user.id,
     );
@@ -170,8 +158,8 @@ export class PlayersController {
   @Get(':id/bans')
   @Auth(PlayerRole.admin)
   @UseInterceptors(ClassSerializerInterceptor)
-  async getPlayerBans(@Param('id', ObjectIdValidationPipe) playerId: string) {
-    return await this.playerBansService.getPlayerBans(playerId);
+  async getPlayerBans(@Param('id', PlayerByIdPipe) player: Player) {
+    return await this.playerBansService.getPlayerBans(player.id);
   }
 
   @Post(':id/bans')
@@ -192,22 +180,17 @@ export class PlayersController {
   @UseInterceptors(ClassSerializerInterceptor)
   @HttpCode(200)
   async updatePlayerBan(
-    @Param('playerId', ObjectIdValidationPipe) playerId: string,
+    @Param('id', PlayerByIdPipe) player: Player,
     @Param('banId', ObjectIdValidationPipe) banId: string,
     @Query('revoke') revoke: any,
     @User() user: Player,
   ) {
-    const player = await this.playersService.getById(playerId);
-    if (!player) {
-      throw new NotFoundException('player not found');
-    }
-
     const ban = await this.playerBansService.getById(banId);
     if (!ban) {
       throw new NotFoundException('ban not found');
     }
 
-    if (ban.player.toString() !== playerId) {
+    if (ban.player.toString() !== player.id) {
       throw new BadRequestException("the given ban is not of the user's");
     }
 
@@ -218,12 +201,10 @@ export class PlayersController {
 
   @Get(':id/linked-profiles')
   @UseInterceptors(ClassSerializerInterceptor)
-  async getPlayerLinkedProfiles(
-    @Param('id', ObjectIdValidationPipe) playerId: string,
-  ) {
+  async getPlayerLinkedProfiles(@Param('id', PlayerByIdPipe) player: Player) {
     const linkedProfiles = await this.linkedProfilesService.getLinkedProfiles(
-      playerId,
+      player.id,
     );
-    return new LinkedProfiles(playerId, linkedProfiles);
+    return new LinkedProfiles(player.id, linkedProfiles);
   }
 }

--- a/src/players/controllers/players.controller.ts
+++ b/src/players/controllers/players.controller.ts
@@ -36,6 +36,8 @@ import { ForceCreatePlayer } from '../dto/force-create-player';
 import { PlayerRole } from '../models/player-role';
 import { LinkedProfilesService } from '../services/linked-profiles.service';
 import { LinkedProfiles } from '../dto/linked-profiles';
+import { ObjectIdOrSteamIdPipe } from '@/shared/pipes/object-id-or-steam-id.pipe';
+import { ObjectIdOrSteamId } from '@/shared/models/object-id-or-steam-id';
 
 @Controller('players')
 @UseInterceptors(CacheInterceptor)
@@ -57,8 +59,16 @@ export class PlayersController {
   @Get(':id')
   @UseInterceptors(ClassSerializerInterceptor)
   @UseFilters(DocumentNotFoundFilter)
-  async getPlayer(@Param('id', ObjectIdValidationPipe) playerId: string) {
-    return this.playersService.getById(playerId);
+  async getPlayer(
+    @Param('id', ObjectIdOrSteamIdPipe) playerId: ObjectIdOrSteamId,
+  ) {
+    switch (playerId.type) {
+      case 'object-id':
+        return this.playersService.getById(playerId.objectId);
+
+      case 'steam-id':
+        return this.playersService.findBySteamId(playerId.steamId64);
+    }
   }
 
   @Post()

--- a/src/players/pipes/player-by-id.pipe.spec.ts
+++ b/src/players/pipes/player-by-id.pipe.spec.ts
@@ -1,0 +1,79 @@
+import { mongooseTestingModule } from '@/utils/testing-mongoose-module';
+import { getConnectionToken, MongooseModule } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { Connection } from 'mongoose';
+import { Player, PlayerDocument, playerSchema } from '../models/player';
+import { PlayersService } from '../services/players.service';
+import { PlayerByIdPipe } from './player-by-id.pipe';
+
+jest.mock('../services/players.service');
+
+describe('PlayerByIdPipe', () => {
+  let pipe: PlayerByIdPipe;
+  let mongod: MongoMemoryServer;
+  let connection: Connection;
+  let playersService: PlayersService;
+
+  beforeAll(async () => (mongod = await MongoMemoryServer.create()));
+  afterAll(async () => mongod.stop());
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        mongooseTestingModule(mongod),
+        MongooseModule.forFeature([
+          {
+            name: Player.name,
+            schema: playerSchema,
+          },
+        ]),
+      ],
+      providers: [PlayersService],
+    }).compile();
+
+    playersService = module.get(PlayersService);
+    pipe = new PlayerByIdPipe(playersService);
+    connection = module.get(getConnectionToken());
+  });
+
+  afterEach(async () => {
+    // @ts-expect-error
+    await playersService._reset();
+    await connection.close();
+  });
+
+  it('should be defined', () => {
+    expect(pipe).toBeDefined();
+  });
+
+  describe('given a valid object id', () => {
+    let player: Player;
+
+    beforeEach(async () => {
+      // @ts-expect-error
+      player = await playersService._createOne();
+    });
+
+    it('should fetch the player by id', async () => {
+      const p = await pipe.transform(player.id);
+      expect(p.id).toEqual(player.id);
+    });
+  });
+
+  describe('given a valid steam id', () => {
+    let player: PlayerDocument;
+
+    beforeEach(async () => {
+      // @ts-expect-error
+      player = await playersService._createOne();
+      player.steamId = '76561198074409147';
+      await player.save();
+    });
+
+    it('should fetch the player by steam id', async () => {
+      const p = await pipe.transform(player.steamId);
+      expect(p.id).toEqual(player.id);
+    });
+  });
+});

--- a/src/players/pipes/player-by-id.pipe.spec.ts
+++ b/src/players/pipes/player-by-id.pipe.spec.ts
@@ -1,8 +1,9 @@
 import { mongooseTestingModule } from '@/utils/testing-mongoose-module';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { getConnectionToken, MongooseModule } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { Connection } from 'mongoose';
+import { Connection, Types } from 'mongoose';
 import { Player, PlayerDocument, playerSchema } from '../models/player';
 import { PlayersService } from '../services/players.service';
 import { PlayerByIdPipe } from './player-by-id.pipe';
@@ -74,6 +75,28 @@ describe('PlayerByIdPipe', () => {
     it('should fetch the player by steam id', async () => {
       const p = await pipe.transform(player.steamId);
       expect(p.id).toEqual(player.id);
+    });
+  });
+
+  describe('given an id of non-existing player', () => {
+    let playerId: string;
+
+    beforeEach(() => {
+      playerId = new Types.ObjectId().toString();
+    });
+
+    it('should throw a 404 error', async () => {
+      await expect(() => pipe.transform(playerId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('given an invalid id', () => {
+    it('should throw a 400 error', async () => {
+      await expect(() => pipe.transform('invalidsteamid')).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 });

--- a/src/players/pipes/player-by-id.pipe.ts
+++ b/src/players/pipes/player-by-id.pipe.ts
@@ -1,0 +1,31 @@
+import { ObjectIdOrSteamIdPipe } from '@/shared/pipes/object-id-or-steam-id.pipe';
+import { Injectable, NotFoundException, PipeTransform } from '@nestjs/common';
+import { Error } from 'mongoose';
+import { Player } from '../models/player';
+import { PlayersService } from '../services/players.service';
+
+@Injectable()
+export class PlayerByIdPipe implements PipeTransform<string, Promise<Player>> {
+  private objectIdOrSteamIdValidationPipe = new ObjectIdOrSteamIdPipe();
+
+  constructor(private playersService: PlayersService) {}
+
+  async transform(value: string): Promise<Player> {
+    try {
+      const playerId = this.objectIdOrSteamIdValidationPipe.transform(value);
+      switch (playerId.type) {
+        case 'object-id':
+          return await this.playersService.getById(playerId.objectId);
+
+        case 'steam-id':
+          return await this.playersService.findBySteamId(playerId.steamId64);
+      }
+    } catch (error) {
+      if (error instanceof Error.DocumentNotFoundError) {
+        throw new NotFoundException();
+      } else {
+        throw error;
+      }
+    }
+  }
+}

--- a/src/shared/models/object-id-or-steam-id.ts
+++ b/src/shared/models/object-id-or-steam-id.ts
@@ -1,0 +1,11 @@
+interface ObjectId {
+  type: 'object-id';
+  objectId: string;
+}
+
+interface SteamId {
+  type: 'steam-id';
+  steamId64: string;
+}
+
+export type ObjectIdOrSteamId = ObjectId | SteamId;

--- a/src/shared/pipes/object-id-or-steam-id.pipe.spec.ts
+++ b/src/shared/pipes/object-id-or-steam-id.pipe.spec.ts
@@ -1,0 +1,43 @@
+import { BadRequestException } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { ObjectIdOrSteamIdPipe } from './object-id-or-steam-id.pipe';
+import { ObjectIdValidationPipe } from './object-id-validation.pipe';
+import { SteamIdValidationPipe } from './steam-id-validation.pipe';
+
+describe('ObjectIdOrSteamIdPipe', () => {
+  let pipe: ObjectIdOrSteamIdPipe;
+
+  beforeEach(() => {
+    pipe = new ObjectIdOrSteamIdPipe();
+  });
+
+  it('should be defined', () => {
+    expect(pipe).toBeDefined();
+  });
+
+  describe('given a valid object id', () => {
+    it('should return the object id', () => {
+      const objectId = new Types.ObjectId().toString();
+      expect(pipe.transform(objectId)).toEqual({
+        type: 'object-id',
+        objectId,
+      });
+    });
+  });
+
+  describe('given a valid steam id', () => {
+    it('should return the id id', () => {
+      const steamId64 = '76561197960287930';
+      expect(pipe.transform('76561197960287930')).toEqual({
+        type: 'steam-id',
+        steamId64,
+      });
+    });
+  });
+
+  describe('given an invalid id', () => {
+    it('should throw an exception', () => {
+      expect(() => pipe.transform('wontwork')).toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/shared/pipes/object-id-or-steam-id.pipe.ts
+++ b/src/shared/pipes/object-id-or-steam-id.pipe.ts
@@ -1,0 +1,34 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { ObjectIdOrSteamId } from '../models/object-id-or-steam-id';
+import { ObjectIdValidationPipe } from './object-id-validation.pipe';
+import { SteamIdValidationPipe } from './steam-id-validation.pipe';
+
+@Injectable()
+export class ObjectIdOrSteamIdPipe
+  implements PipeTransform<string, ObjectIdOrSteamId>
+{
+  private objectIdValidationPipe = new ObjectIdValidationPipe();
+  private steamIdValidationPipe = new SteamIdValidationPipe();
+
+  transform(value: string): ObjectIdOrSteamId {
+    try {
+      const objectId = this.objectIdValidationPipe.transform(value);
+      return {
+        type: 'object-id',
+        objectId,
+      };
+      // eslint-disable-next-line no-empty
+    } catch (error) {}
+
+    try {
+      const steamId64 = this.steamIdValidationPipe.transform(value);
+      return {
+        type: 'steam-id',
+        steamId64,
+      };
+      // eslint-disable-next-line no-empty
+    } catch (error) {}
+
+    throw new BadRequestException('The provided ID is invalid');
+  }
+}

--- a/src/shared/pipes/steam-id-validation.pipe.spec.ts
+++ b/src/shared/pipes/steam-id-validation.pipe.spec.ts
@@ -1,0 +1,43 @@
+import { BadRequestException } from '@nestjs/common';
+import { SteamIdValidationPipe } from './steam-id-validation.pipe';
+
+describe('SteamIdValidationPipe', () => {
+  const malySteamId64 = '76561198074409147';
+  let pipe: SteamIdValidationPipe;
+
+  beforeEach(() => {
+    pipe = new SteamIdValidationPipe();
+  });
+
+  it('should be defined', () => {
+    expect(pipe).toBeDefined();
+  });
+
+  describe('given a valid SteamID64', () => {
+    it('should pass and return the SteamID64', () => {
+      expect(pipe.transform('76561198074409147')).toEqual(malySteamId64);
+    });
+  });
+
+  describe('given a valid SteamID', () => {
+    it('should pass and return the SteamID64', () => {
+      expect(pipe.transform('STEAM_0:1:57071709')).toEqual(malySteamId64);
+    });
+  });
+
+  describe('given an invalid SteamID', () => {
+    it('should throw an exception', () => {
+      expect(() => pipe.transform('invalidsteamid')).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('given a valid SteamID, but not of a valid individual', () => {
+    it('should throw an exception', () => {
+      expect(() => pipe.transform('[U:1:46143802:10]')).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/src/shared/pipes/steam-id-validation.pipe.ts
+++ b/src/shared/pipes/steam-id-validation.pipe.ts
@@ -1,0 +1,18 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import * as SteamID from 'steamid';
+
+@Injectable()
+export class SteamIdValidationPipe implements PipeTransform {
+  transform(value: string) {
+    try {
+      const sid = new SteamID(value);
+      if (sid.isValidIndividual()) {
+        return sid.getSteamID64();
+      } else {
+        throw new BadRequestException('The provided SteamID is invalid');
+      }
+    } catch (error) {
+      throw new BadRequestException(error.message);
+    }
+  }
+}


### PR DESCRIPTION
Make the `/players/:player-id` endpoint accept SteamID next to ObjectID. This accepts SteamID in all valid formats: SteamID, SteamID3 and SteamID64.