### PR TITLE
fix(games): launch orphaned games in a critical section

### DIFF
--- a/src/games/services/game-launcher.service.spec.ts
+++ b/src/games/services/game-launcher.service.spec.ts
@@ -124,9 +124,10 @@ describe('GameLauncherService', () => {
     });
 
     it('should launch orphaned games', async () => {
-      const spy = jest.spyOn(service, 'launch');
       await service.launchOrphanedGames();
-      expect(spy).toHaveBeenCalledWith(game.id);
+      expect(serverConfiguratorService.configureServer).toHaveBeenCalledWith(
+        game.id,
+      );
     });
   });
 });

--- a/src/games/services/game-launcher.service.ts
+++ b/src/games/services/game-launcher.service.ts
@@ -4,6 +4,7 @@ import { GameServersService } from '@/game-servers/services/game-servers.service
 import { ServerConfiguratorService } from './server-configurator.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Game } from '../models/game';
+import { Mutex } from 'async-mutex';
 
 /**
  * This service is responsible for launching a single game.
@@ -14,6 +15,7 @@ import { Game } from '../models/game';
 @Injectable()
 export class GameLauncherService {
   private logger = new Logger(GameLauncherService.name);
+  private mutex = new Mutex();
 
   constructor(
     @Inject(forwardRef(() => GamesService)) private gamesService: GamesService,
@@ -28,55 +30,61 @@ export class GameLauncherService {
    * @memberof GameLauncherService
    */
   async launch(gameId: string): Promise<Game> {
-    let game = await this.gamesService.getById(gameId);
+    return await this.mutex.runExclusive(async () => {
+      let game = await this.gamesService.getById(gameId);
 
-    if (!game.isInProgress()) {
-      this.logger.warn(
-        `trying to launch game #${game.number} that has already been ended`,
-      );
-    }
+      if (!game.isInProgress()) {
+        this.logger.warn(
+          `trying to launch game #${game.number} that has already been ended`,
+        );
+      }
 
-    try {
-      // step 1: obtain a free server
-      const gameServer = await this.gameServersService.assignGameServer(
-        game.id,
-      );
-      this.logger.verbose(
-        `using server ${gameServer.name} for game #${game.number}`,
-      );
+      try {
+        // step 1: obtain a free server
+        const gameServer = await this.gameServersService.assignGameServer(
+          game.id,
+        );
+        this.logger.verbose(
+          `using server ${gameServer.name} for game #${game.number}`,
+        );
 
-      // step 2: obtain logsecret
-      const logSecret = await gameServer.getLogsecret();
-      this.logger.debug(`[${gameServer.name}] logsecret is ${game.logSecret}`);
-      game = await this.gamesService.update(game.id, { logSecret });
+        // step 2: obtain logsecret
+        const logSecret = await gameServer.getLogsecret();
+        game = await this.gamesService.update(game.id, { logSecret });
+        this.logger.debug(
+          `[${gameServer.name}] logsecret is ${game.logSecret}`,
+        );
 
-      // step 3: configure server
-      const { connectString, stvConnectString } =
-        await this.serverConfiguratorService.configureServer(game.id);
+        // step 3: configure server
+        const { connectString, stvConnectString } =
+          await this.serverConfiguratorService.configureServer(game.id);
 
-      game = await this.gamesService.update(game.id, {
-        $set: {
-          connectString,
-          stvConnectString,
-        },
-        $inc: {
-          connectInfoVersion: 1,
-        },
-      });
+        game = await this.gamesService.update(game.id, {
+          $set: {
+            connectString,
+            stvConnectString,
+          },
+          $inc: {
+            connectInfoVersion: 1,
+          },
+        });
 
-      this.logger.verbose(`game #${game.number} initialized`);
-      return game;
-    } catch (error) {
-      this.logger.error(`Error launching game #${game.number}: ${error}`);
-    }
+        this.logger.verbose(`game #${game.number} initialized`);
+        return game;
+      } catch (error) {
+        this.logger.error(`Error launching game #${game.number}: ${error}`);
+      }
+    });
   }
 
-  @Cron(CronExpression.EVERY_MINUTE) // every minute
+  @Cron(CronExpression.EVERY_MINUTE)
   async launchOrphanedGames() {
-    const orphanedGames = await this.gamesService.getOrphanedGames();
-    for (const game of orphanedGames) {
-      this.logger.verbose(`launching game #${game.number}...`);
-      await this.launch(game.id);
-    }
+    this.mutex.runExclusive(async () => {
+      const orphanedGames = await this.gamesService.getOrphanedGames();
+      for (const game of orphanedGames) {
+        this.logger.verbose(`launching game #${game.number}...`);
+        await this.launch(game.id);
+      }
+    });
   }
 }

--- a/src/games/services/game-launcher.service.ts
+++ b/src/games/services/game-launcher.service.ts
@@ -31,49 +31,7 @@ export class GameLauncherService {
    */
   async launch(gameId: string): Promise<Game> {
     return await this.mutex.runExclusive(async () => {
-      let game = await this.gamesService.getById(gameId);
-
-      if (!game.isInProgress()) {
-        this.logger.warn(
-          `trying to launch game #${game.number} that has already been ended`,
-        );
-      }
-
-      try {
-        // step 1: obtain a free server
-        const gameServer = await this.gameServersService.assignGameServer(
-          game.id,
-        );
-        this.logger.verbose(
-          `using server ${gameServer.name} for game #${game.number}`,
-        );
-
-        // step 2: obtain logsecret
-        const logSecret = await gameServer.getLogsecret();
-        game = await this.gamesService.update(game.id, { logSecret });
-        this.logger.debug(
-          `[${gameServer.name}] logsecret is ${game.logSecret}`,
-        );
-
-        // step 3: configure server
-        const { connectString, stvConnectString } =
-          await this.serverConfiguratorService.configureServer(game.id);
-
-        game = await this.gamesService.update(game.id, {
-          $set: {
-            connectString,
-            stvConnectString,
-          },
-          $inc: {
-            connectInfoVersion: 1,
-          },
-        });
-
-        this.logger.verbose(`game #${game.number} initialized`);
-        return game;
-      } catch (error) {
-        this.logger.error(`Error launching game #${game.number}: ${error}`);
-      }
+      return await this.doLaunch(gameId);
     });
   }
 
@@ -83,8 +41,52 @@ export class GameLauncherService {
       const orphanedGames = await this.gamesService.getOrphanedGames();
       for (const game of orphanedGames) {
         this.logger.verbose(`launching game #${game.number}...`);
-        await this.launch(game.id);
+        await this.doLaunch(game.id);
       }
     });
+  }
+
+  private async doLaunch(gameId: string): Promise<Game> {
+    let game = await this.gamesService.getById(gameId);
+
+    if (!game.isInProgress()) {
+      this.logger.warn(
+        `trying to launch game #${game.number} that has already been ended`,
+      );
+    }
+
+    try {
+      // step 1: obtain a free server
+      const gameServer = await this.gameServersService.assignGameServer(
+        game.id,
+      );
+      this.logger.verbose(
+        `using server ${gameServer.name} for game #${game.number}`,
+      );
+
+      // step 2: obtain logsecret
+      const logSecret = await gameServer.getLogsecret();
+      game = await this.gamesService.update(game.id, { logSecret });
+      this.logger.debug(`[${gameServer.name}] logsecret is ${game.logSecret}`);
+
+      // step 3: configure server
+      const { connectString, stvConnectString } =
+        await this.serverConfiguratorService.configureServer(game.id);
+
+      game = await this.gamesService.update(game.id, {
+        $set: {
+          connectString,
+          stvConnectString,
+        },
+        $inc: {
+          connectInfoVersion: 1,
+        },
+      });
+
+      this.logger.verbose(`game #${game.number} initialized`);
+      return game;
+    } catch (error) {
+      this.logger.error(`Error launching game #${game.number}: ${error}`);
+    }
   }
 }

--- a/src/games/services/game-launcher.service.ts
+++ b/src/games/services/game-launcher.service.ts
@@ -30,14 +30,14 @@ export class GameLauncherService {
    * @memberof GameLauncherService
    */
   async launch(gameId: string): Promise<Game> {
-    return await this.mutex.runExclusive(async () => {
-      return await this.doLaunch(gameId);
-    });
+    return await this.mutex.runExclusive(
+      async () => await this.doLaunch(gameId),
+    );
   }
 
   @Cron(CronExpression.EVERY_MINUTE)
   async launchOrphanedGames() {
-    this.mutex.runExclusive(async () => {
+    return await this.mutex.runExclusive(async () => {
       const orphanedGames = await this.gamesService.getOrphanedGames();
       for (const game of orphanedGames) {
         this.logger.verbose(`launching game #${game.number}...`);


### PR DESCRIPTION
Handle the situation where an orphaned game is launched, but the same game is being assigned a gameserver at the exact same moment.