### PR TITLE
feat(game-servers): add start() method

### DIFF
--- a/src/game-servers/models/game-server.ts
+++ b/src/game-servers/models/game-server.ts
@@ -52,6 +52,13 @@ export class GameServer extends MongooseDocument {
   async getLogsecret(): Promise<string> {
     throw new NotImplementedError();
   }
+
+  /**
+   * Start the gameserver (in case it needs to be started).
+   */
+  async start(): Promise<this> {
+    return Promise.resolve(this);
+  }
 }
 
 export type GameServerDocument = GameServer & Document;

--- a/src/game-servers/providers/static-game-server/controllers/static-game-servers.controller.spec.ts
+++ b/src/game-servers/providers/static-game-server/controllers/static-game-servers.controller.spec.ts
@@ -57,6 +57,7 @@ describe('GameServers Controller', () => {
       isClean: true,
       lastHeartbeatAt: new Date(),
       priority: 1,
+      start: jest.fn().mockResolvedValue(mockGameServer),
     };
   });
 

--- a/src/games/services/game-launcher.service.spec.ts
+++ b/src/games/services/game-launcher.service.spec.ts
@@ -68,6 +68,7 @@ describe('GameLauncherService', () => {
         .fn()
         .mockRejectedValue(new Error('not implemented')),
       getLogsecret: jest.fn().mockResolvedValue('FAKE_LOGSECRET'),
+      start: jest.fn().mockResolvedValue(mockGameServer),
     };
   });
 

--- a/src/games/services/game-runtime.service.spec.ts
+++ b/src/games/services/game-runtime.service.spec.ts
@@ -83,6 +83,7 @@ describe('GameRuntimeService', () => {
       rcon: jest.fn().mockRejectedValue('not implemented'),
       voiceChannelName: jest.fn(),
       getLogsecret: jest.fn().mockRejectedValue(new NotImplementedError()),
+      start: jest.fn().mockResolvedValue(mockGameServer),
     };
 
     gameServersService.getById.mockResolvedValue(mockGameServer as any);

--- a/src/games/services/server-configurator.service.spec.ts
+++ b/src/games/services/server-configurator.service.spec.ts
@@ -122,6 +122,7 @@ describe('ServerConfiguratorService', () => {
       rcon: jest.fn(),
       voiceChannelName: jest.fn(),
       getLogsecret: jest.fn(),
+      start: jest.fn().mockResolvedValue(mockGameServer),
     };
   });
 
@@ -184,6 +185,17 @@ describe('ServerConfiguratorService', () => {
       // @ts-expect-error
       await playersService._reset();
       await gameModel.deleteMany({});
+    });
+
+    it('should wait for the gameserver to start', async () => {
+      const ret = service.configureServer(game.id).then(() => {
+        expect(mockGameServer.start).toHaveBeenCalledTimes(1);
+      });
+      for (let i = 0; i < stableTestCoefficient; i++) {
+        jest.runAllTimers();
+        await flushPromises();
+      }
+      return ret;
     });
 
     it('should execute correct rcon commands', async () => {

--- a/src/games/services/server-configurator.service.ts
+++ b/src/games/services/server-configurator.service.ts
@@ -46,6 +46,9 @@ export class ServerConfiguratorService {
     const game = await this.gamesService.getById(gameId);
     const server = await this.gameServersService.getById(game.gameServer);
 
+    this.logger.verbose(`starting gameserver ${server.name}`);
+    await server.start();
+
     this.logger.verbose(`configuring server ${server.name}...`);
 
     let rcon: Rcon;


### PR DESCRIPTION
Add the `GameServer.start()` method that starts the gameserver and waits for it to be started. After `GameServer.start()` is called, the `GameServer.rcon()` should always return a valid RCON connection.