### PR TITLE
fix(game-servers): remove deprecated APIs

### DIFF
--- a/e2e/game-server-heartbeat.e2e-spec.ts
+++ b/e2e/game-server-heartbeat.e2e-spec.ts
@@ -21,9 +21,9 @@ describe('Game server heartbeat (e2e)', () => {
   });
 
   describe('denies request on wrong secret', () => {
-    it('POST /game-servers', async () => {
+    it('POST /static-game-servers', async () => {
       return request(app.getHttpServer())
-        .post(`/game-servers`)
+        .post(`/static-game-servers`)
         .send({
           name: 'test',
           address: '192.168.1.1',
@@ -36,9 +36,9 @@ describe('Game server heartbeat (e2e)', () => {
   });
 
   describe('adds game server', () => {
-    it('POST /game-servers', async () => {
+    it('POST /static-game-servers', async () => {
       return request(app.getHttpServer())
-        .post('/game-servers')
+        .post('/static-game-servers')
         .send({
           name: 'test',
           address: '192.168.1.1',

--- a/src/game-servers/controllers/game-servers.controller.spec.ts
+++ b/src/game-servers/controllers/game-servers.controller.spec.ts
@@ -1,20 +1,10 @@
-import { Environment } from '@/environment/environment';
 import { Test, TestingModule } from '@nestjs/testing';
 import { plainToClass } from 'class-transformer';
 import { GameServer } from '../models/game-server';
-import { GameServerDiagnosticsService } from '../providers/static-game-server/services/game-server-diagnostics.service';
-import { StaticGameServersService } from '../providers/static-game-server/services/static-game-servers.service';
 import { GameServersService } from '../services/game-servers.service';
 import { GameServersController } from './game-servers.controller';
 
 jest.mock('../services/game-servers.service');
-jest.mock(
-  '../providers/static-game-server/services/static-game-servers.service',
-);
-jest.mock(
-  '../providers/static-game-server/services/game-server-diagnostics.service',
-);
-jest.mock('@/environment/environment');
 
 describe('GameServersController', () => {
   let controller: GameServersController;
@@ -23,12 +13,7 @@ describe('GameServersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [GameServersController],
-      providers: [
-        GameServersService,
-        StaticGameServersService,
-        GameServerDiagnosticsService,
-        Environment,
-      ],
+      providers: [GameServersService],
     }).compile();
 
     controller = module.get<GameServersController>(GameServersController);

--- a/src/game-servers/controllers/game-servers.controller.ts
+++ b/src/game-servers/controllers/game-servers.controller.ts
@@ -5,6 +5,8 @@ import {
   Controller,
   Get,
   Param,
+  Post,
+  Redirect,
   UseFilters,
   UseInterceptors,
 } from '@nestjs/common';
@@ -22,4 +24,10 @@ export class GameServersController {
   ) {
     return await this.gameServersService.getById(gameServerId);
   }
+
+  // TODO Remove
+  @Post()
+  @Redirect('/static-game-servers', 308)
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  staticGameServerHeartbeat() {}
 }

--- a/src/game-servers/controllers/game-servers.controller.ts
+++ b/src/game-servers/controllers/game-servers.controller.ts
@@ -1,40 +1,18 @@
-import { Auth } from '@/auth/decorators/auth.decorator';
-import { Secret } from '@/auth/decorators/secret.decorator';
-import { SecretPurpose } from '@/auth/secret-purpose';
-import { Environment } from '@/environment/environment';
-import { PlayerRole } from '@/players/models/player-role';
-import { Deprecated } from '@/shared/decorators/deprecated';
 import { DocumentNotFoundFilter } from '@/shared/filters/document-not-found.filter';
 import { ObjectIdValidationPipe } from '@/shared/pipes/object-id-validation.pipe';
 import {
-  Body,
   ClassSerializerInterceptor,
   Controller,
   Get,
-  HttpCode,
   Param,
-  Post,
   UseFilters,
   UseInterceptors,
-  UsePipes,
-  ValidationPipe,
 } from '@nestjs/common';
-import { RealIp } from 'nestjs-real-ip';
-import { GameServerHeartbeat } from '../providers/static-game-server/dto/game-server-heartbeat';
-import { GameServerDiagnosticsService } from '../providers/static-game-server/services/game-server-diagnostics.service';
-import { StaticGameServersService } from '../providers/static-game-server/services/static-game-servers.service';
 import { GameServersService } from '../services/game-servers.service';
 
 @Controller('game-servers')
 export class GameServersController {
-  constructor(
-    private gameServersService: GameServersService,
-    /** TODO v9.0 remove */
-    private staticGameServersService: StaticGameServersService,
-    /** TODO v9.0 remove */
-    private gameServerDiagnosticsService: GameServerDiagnosticsService,
-    private environment: Environment,
-  ) {}
+  constructor(private gameServersService: GameServersService) {}
 
   @Get(':id')
   @UseInterceptors(ClassSerializerInterceptor)
@@ -43,49 +21,5 @@ export class GameServersController {
     @Param('id', ObjectIdValidationPipe) gameServerId: string,
   ) {
     return await this.gameServersService.getById(gameServerId);
-  }
-
-  /** TODO v9.0 remove */
-  @Get()
-  @UseInterceptors(ClassSerializerInterceptor)
-  async getAllGameServers() {
-    return await this.staticGameServersService.getAllGameServers();
-  }
-
-  /** TODO v9.0 remove */
-  @Post()
-  @Secret(SecretPurpose.gameServer)
-  @UsePipes(ValidationPipe)
-  @UseInterceptors(ClassSerializerInterceptor)
-  @Deprecated()
-  async gameServerHeartbeat(
-    @Body() heartbeat: GameServerHeartbeat,
-    @RealIp() internalIpAddress: string,
-  ) {
-    return this.staticGameServersService.heartbeat({
-      ...heartbeat,
-      internalIpAddress: heartbeat.internalIpAddress ?? internalIpAddress,
-    });
-  }
-
-  /** TODO v9.0 remove */
-  @Post(':id/diagnostics')
-  @Auth(PlayerRole.superUser)
-  @UseFilters(DocumentNotFoundFilter)
-  @HttpCode(202)
-  @Deprecated()
-  async runDiagnostics(
-    @Param('id', ObjectIdValidationPipe) gameServerId: string,
-  ) {
-    const id = await this.gameServerDiagnosticsService.runDiagnostics(
-      gameServerId,
-    );
-
-    return {
-      diagnosticRunId: id,
-      tracking: {
-        url: `${this.environment.apiUrl}/game-server-diagnostics/${id}`,
-      },
-    };
   }
 }

--- a/src/game-servers/game-servers.module.ts
+++ b/src/game-servers/game-servers.module.ts
@@ -5,6 +5,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { GameServer, gameServerSchema } from './models/game-server';
 import { GameServersProvidersModule } from './providers/game-servers-providers.module';
 import { GameServersController } from './controllers/game-servers.controller';
+import { StaticGameServerModule } from './providers/static-game-server/static-game-server.module';
 
 const gameServerModelProvider = MongooseModule.forFeature([
   {
@@ -21,6 +22,9 @@ const gameServerModelProvider = MongooseModule.forFeature([
     gameServerModelProvider,
     GameServersProvidersModule.configure(),
     forwardRef(() => GamesModule),
+
+    // FIXME This is a workaround for (probably) as NestJS bug, this shouldn't be needed here.
+    StaticGameServerModule,
   ],
   providers: [GameServersService],
   exports: [GameServersService, gameServerModelProvider],

--- a/src/game-servers/game-servers.module.ts
+++ b/src/game-servers/game-servers.module.ts
@@ -5,7 +5,6 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { GameServer, gameServerSchema } from './models/game-server';
 import { GameServersProvidersModule } from './providers/game-servers-providers.module';
 import { GameServersController } from './controllers/game-servers.controller';
-import { StaticGameServerModule } from './providers/static-game-server/static-game-server.module';
 
 const gameServerModelProvider = MongooseModule.forFeature([
   {
@@ -22,9 +21,6 @@ const gameServerModelProvider = MongooseModule.forFeature([
     gameServerModelProvider,
     GameServersProvidersModule.configure(),
     forwardRef(() => GamesModule),
-
-    // FIXME This is a workaround for (probably) as NestJS bug, this shouldn't be needed here.
-    StaticGameServerModule,
   ],
   providers: [GameServersService],
   exports: [GameServersService, gameServerModelProvider],

--- a/src/game-servers/providers/static-game-server/static-game-server.module.ts
+++ b/src/game-servers/providers/static-game-server/static-game-server.module.ts
@@ -32,11 +32,6 @@ import { staticGameServerModelProvider } from './static-game-server-model.provid
     RconConnection,
     LogForwarding,
   ],
-  exports: [
-    StaticGameServersService,
-    /** TODO v9.0 remove */
-    GameServerDiagnosticsService,
-  ],
   controllers: [StaticGameServersController, GameServerDiagnosticsController],
 })
 export class StaticGameServerModule {}


### PR DESCRIPTION
BREAKING CHANGE: the `/game-servers` endpoint is no longer an endpoint for the static game servers
BREAKING CHANGE: the gameserver heartbeat endpoint has been moved to `/static-game-servers`