### PR TITLE
fix(games): better gameChanges event

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -58,7 +58,11 @@ export class Events {
   readonly mapPoolChange = new Subject<{ maps: Map[] }>();
 
   readonly gameCreated = new Subject<{ game: Game }>();
-  readonly gameChanges = new Subject<{ game: Game; adminId?: string }>();
+  readonly gameChanges = new Subject<{
+    newGame: Game;
+    oldGame: Game;
+    adminId?: string;
+  }>();
 
   readonly substituteRequested = new Subject<{
     gameId: string;

--- a/src/game-servers/services/game-servers.service.ts
+++ b/src/game-servers/services/game-servers.service.ts
@@ -12,7 +12,7 @@ import { GamesService } from '@/games/services/games.service';
 import { GameServer, GameServerDocument } from '../models/game-server';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types, UpdateQuery } from 'mongoose';
-import { concatMap, filter, groupBy, take } from 'rxjs';
+import { filter } from 'rxjs';
 import { plainToInstance } from 'class-transformer';
 import { GameServerProvider } from '../game-server-provider';
 import { Game } from '@/games/models/game';
@@ -42,15 +42,14 @@ export class GameServersService
   onModuleInit() {
     this.events.gameChanges
       .pipe(
-        groupBy(({ game }) => game.id),
-        concatMap((group) =>
-          group.pipe(
-            filter(({ game }) => !game.isInProgress()),
-            take(1),
-          ),
+        filter(
+          ({ oldGame, newGame }) =>
+            oldGame.isInProgress() && !newGame.isInProgress(),
         ),
       )
-      .subscribe(async ({ game }) => await this.maybeReleaseGameServer(game));
+      .subscribe(
+        async ({ newGame }) => await this.maybeReleaseGameServer(newGame),
+      );
   }
 
   onApplicationBootstrap() {

--- a/src/games/gateways/games.gateway.spec.ts
+++ b/src/games/gateways/games.gateway.spec.ts
@@ -75,7 +75,7 @@ describe('GamesGateway', () => {
 
   describe('when the gameChanges event is emitted', () => {
     beforeEach(() => {
-      events.gameChanges.next({ game: mockGame });
+      events.gameChanges.next({ newGame: mockGame, oldGame: mockGame });
     });
 
     it('should emit the created game via the socket', () => {

--- a/src/games/gateways/games.gateway.ts
+++ b/src/games/gateways/games.gateway.ts
@@ -42,8 +42,8 @@ export class GamesGateway implements OnGatewayInit, OnModuleInit {
     this.events.gameCreated.subscribe(({ game }) =>
       this.socket.emit(WebsocketEvent.gameCreated, instanceToPlain(game)),
     );
-    this.events.gameChanges.subscribe(({ game }) =>
-      this.socket.emit(WebsocketEvent.gameUpdated, instanceToPlain(game)),
+    this.events.gameChanges.subscribe(({ newGame }) =>
+      this.socket.emit(WebsocketEvent.gameUpdated, instanceToPlain(newGame)),
     );
   }
 }

--- a/src/games/services/game-event-handler.service.spec.ts
+++ b/src/games/services/game-event-handler.service.spec.ts
@@ -103,7 +103,7 @@ describe('GameEventHandlerService', () => {
 
     it('should emit the gameChanges event', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => {
+      events.gameChanges.subscribe(({ newGame: game }) => {
         event = game;
       });
 
@@ -147,7 +147,7 @@ describe('GameEventHandlerService', () => {
 
     it('should emit the gameChanges events', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => (event = game));
+      events.gameChanges.subscribe(({ newGame: game }) => (event = game));
       await service.onMatchEnded(mockGame.id);
       expect(event).toMatchObject({ id: mockGame.id, state: GameState.ended });
     });
@@ -221,7 +221,7 @@ describe('GameEventHandlerService', () => {
 
     it('should emit the gameChanges events', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => (event = game));
+      events.gameChanges.subscribe(({ newGame: game }) => (event = game));
       await service.onLogsUploaded(mockGame._id, 'FAKE_LOGS_URL');
       expect(event).toMatchObject({
         id: mockGame.id,
@@ -238,7 +238,7 @@ describe('GameEventHandlerService', () => {
 
     it('should emit the gameChanges event', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => (event = game));
+      events.gameChanges.subscribe(({ newGame: game }) => (event = game));
       await service.onDemoUploaded(mockGame._id, 'FAKE_DEMO_URL');
       expect(event).toMatchObject({
         id: mockGame.id,
@@ -268,7 +268,7 @@ describe('GameEventHandlerService', () => {
 
     it('should emit the gameChanges event', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => (event = game));
+      events.gameChanges.subscribe(({ newGame: game }) => (event = game));
       await service.onPlayerJoining(mockGame.id, player1.steamId);
       expect(event).toMatchObject({ id: mockGame.id });
     });
@@ -287,7 +287,7 @@ describe('GameEventHandlerService', () => {
 
     it('should emit the gameChanges event', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => (event = game));
+      events.gameChanges.subscribe(({ newGame: game }) => (event = game));
       await service.onPlayerConnected(mockGame.id, player1.steamId);
       expect(event).toMatchObject({ id: mockGame.id });
     });
@@ -306,7 +306,7 @@ describe('GameEventHandlerService', () => {
 
     it('should emit an the gameChanges event', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => (event = game));
+      events.gameChanges.subscribe(({ newGame: game }) => (event = game));
       await service.onPlayerDisconnected(mockGame.id, player1.steamId);
       expect(event).toMatchObject({ id: mockGame.id });
     });
@@ -323,7 +323,7 @@ describe('GameEventHandlerService', () => {
 
     it('should emit the gameChanges event', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => (event = game));
+      events.gameChanges.subscribe(({ newGame: game }) => (event = game));
       await service.onScoreReported(mockGame.id, 'Red', '2');
       expect(event).toMatchObject({ id: mockGame.id });
     });

--- a/src/games/services/game-runtime.service.spec.ts
+++ b/src/games/services/game-runtime.service.spec.ts
@@ -189,8 +189,8 @@ describe('GameRuntimeService', () => {
 
     it('should emit the gameChanges event', async () =>
       new Promise<void>((resolve) => {
-        events.gameChanges.subscribe(({ game, adminId }) => {
-          expect(game.id).toEqual(mockGame.id);
+        events.gameChanges.subscribe(({ newGame, adminId }) => {
+          expect(newGame.id).toEqual(mockGame.id);
           expect(adminId).toEqual('FAKE_ADMIN_ID');
           resolve();
         });

--- a/src/games/services/games.service.ts
+++ b/src/games/services/games.service.ts
@@ -213,7 +213,8 @@ export class GamesService {
     update: UpdateQuery<Game>,
     adminId?: string,
   ): Promise<Game> {
-    const game = plainToInstance(
+    const oldGame = await this.getById(gameId);
+    const newGame = plainToInstance(
       Game,
       await this.gameModel
         .findOneAndUpdate({ _id: gameId }, update, { new: true })
@@ -221,8 +222,8 @@ export class GamesService {
         .lean()
         .exec(),
     );
-    this.events.gameChanges.next({ game, adminId });
-    return game;
+    this.events.gameChanges.next({ oldGame, newGame, adminId });
+    return newGame;
   }
 
   /**

--- a/src/games/services/player-substitution.service.spec.ts
+++ b/src/games/services/player-substitution.service.spec.ts
@@ -163,7 +163,7 @@ describe('PlayerSubstitutionService', () => {
 
     it('should emit the gameChanges event', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => {
+      events.gameChanges.subscribe(({ newGame: game }) => {
         event = game;
       });
 
@@ -280,7 +280,7 @@ describe('PlayerSubstitutionService', () => {
     it('should emit the gameChanges event', async () => {
       let event: Game;
 
-      events.gameChanges.subscribe(({ game }) => {
+      events.gameChanges.subscribe(({ newGame: game }) => {
         event = game;
       });
 
@@ -351,7 +351,7 @@ describe('PlayerSubstitutionService', () => {
 
     it('should emit the gameChanges event', async () => {
       let event: Game;
-      events.gameChanges.subscribe(({ game }) => {
+      events.gameChanges.subscribe(({ newGame: game }) => {
         event = game;
       });
 

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -267,7 +267,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
         });
         await this.deleteDiscordAnnouncement(replaceeId);
         this.logger.verbose(`player has taken his own slot`);
-        return game;
+        return newGame;
       }
 
       if (replacement.activeGame) {
@@ -345,7 +345,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
           .replacePlayer(newGame.id, replaceeId, replacementSlot)
           .catch((error) => this.logger.warn(error));
       }
-      return game;
+      return newGame;
     });
   }
 

--- a/src/games/services/player-substitution.service.ts
+++ b/src/games/services/player-substitution.service.ts
@@ -65,7 +65,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
 
   async substitutePlayer(gameId: string, playerId: string, adminId?: string) {
     return await this.mutex.runExclusive(async () => {
-      let game = await this.gamesService.getById(gameId);
+      const game = await this.gamesService.getById(gameId);
       const slot = game.findPlayerSlot(playerId);
       if (!slot) {
         throw new PlayerNotInThisGameError(playerId, gameId);
@@ -84,7 +84,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
       }
 
       const player = await this.playersService.getById(playerId);
-      game = plainToInstance(
+      const newGame = plainToInstance(
         Game,
         await this.gameModel
           .findByIdAndUpdate(
@@ -108,16 +108,16 @@ export class PlayerSubstitutionService implements OnModuleInit {
         `player ${player.name} taking part in game #${game.number} is marked as 'waiting for substitute'`,
       );
 
-      this.events.gameChanges.next({ game });
+      this.events.gameChanges.next({ oldGame: game, newGame });
       this.events.substituteRequested.next({ gameId, playerId, adminId });
 
       const channel = this.discordService?.getPlayersChannel();
       if (channel) {
         const embed = substituteRequest({
-          gameNumber: game.number,
+          gameNumber: newGame.number,
           gameClass: slot.gameClass,
           team: slot.team.toUpperCase(),
-          gameUrl: `${this.environment.clientUrl}/game/${game.id}`,
+          gameUrl: `${this.environment.clientUrl}/game/${newGame.id}`,
         });
 
         const roleToMention = this.discordService.findRole(
@@ -137,16 +137,16 @@ export class PlayerSubstitutionService implements OnModuleInit {
         this.discordNotifications.set(playerId, message);
       }
 
-      if (game.gameServer) {
+      if (newGame.gameServer) {
         this.gameRuntimeService
           .sayChat(
-            game.gameServer.toString(),
+            newGame.gameServer.toString(),
             `Looking for replacement for ${player.name}...`,
           )
           .catch((error) => this.logger.warn(error));
       }
 
-      return game;
+      return newGame;
     });
   }
 
@@ -156,7 +156,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
     adminId?: string,
   ) {
     return await this.mutex.runExclusive(async () => {
-      let game = await this.gamesService.getById(gameId);
+      const game = await this.gamesService.getById(gameId);
       const slot = game.findPlayerSlot(playerId);
       if (!slot) {
         throw new PlayerNotInThisGameError(playerId, gameId);
@@ -179,7 +179,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
         `player ${player.name} taking part in game #${game.number} is marked as 'active'`,
       );
 
-      game = plainToInstance(
+      const newGame = plainToInstance(
         Game,
         await this.gameModel
           .findByIdAndUpdate(
@@ -199,7 +199,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
           .exec(),
       );
 
-      this.events.gameChanges.next({ game });
+      this.events.gameChanges.next({ oldGame: game, newGame });
       this.events.substituteCanceled.next({ gameId, playerId, adminId });
 
       const message = this.discordNotifications.get(playerId);
@@ -208,7 +208,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
         this.discordNotifications.delete(playerId);
       }
 
-      return game;
+      return newGame;
     });
   }
 
@@ -227,7 +227,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
         throw new Error('player is banned');
       }
 
-      let game = await this.gamesService.getById(gameId);
+      const game = await this.gamesService.getById(gameId);
       const slot = game.slots.find(
         (slot) =>
           slot.status === SlotStatus.waitingForSubstitute &&
@@ -239,7 +239,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
       }
 
       if (replaceeId === replacementId) {
-        game = plainToInstance(
+        const newGame = plainToInstance(
           Game,
           await this.gameModel
             .findByIdAndUpdate(
@@ -259,7 +259,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
             .exec(),
         );
 
-        this.events.gameChanges.next({ game });
+        this.events.gameChanges.next({ oldGame: game, newGame });
         this.events.playerReplaced.next({
           gameId,
           replaceeId,
@@ -285,7 +285,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
         $push: { slots: replacementSlot },
       });
 
-      game = plainToInstance(
+      const newGame = plainToInstance(
         Game,
         await this.gameModel
           .findByIdAndUpdate(
@@ -307,7 +307,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
           .exec(),
       );
 
-      this.events.gameChanges.next({ game });
+      this.events.gameChanges.next({ oldGame: game, newGame });
       this.events.playerReplaced.next({
         gameId,
         replaceeId,
@@ -317,7 +317,7 @@ export class PlayerSubstitutionService implements OnModuleInit {
 
       const replacee = await this.playersService.getById(replaceeId);
 
-      if (game.gameServer) {
+      if (newGame.gameServer) {
         this.gameRuntimeService
           .sayChat(
             game.gameServer.toString(),
@@ -329,20 +329,20 @@ export class PlayerSubstitutionService implements OnModuleInit {
       await this.deleteDiscordAnnouncement(replaceeId);
 
       this.logger.verbose(
-        `player ${replacement.name} is replacing ${replacee.name} on ${replacementSlot.gameClass} in game #${game.number}`,
+        `player ${replacement.name} is replacing ${replacee.name} on ${replacementSlot.gameClass} in game #${newGame.number}`,
       );
 
       await this.playersService.updatePlayer(replacement.id.toString(), {
-        activeGame: game.id,
+        activeGame: newGame.id,
       });
 
       await this.playersService.updatePlayer(replacee.id.toString(), {
         $unset: { activeGame: 1 },
       });
 
-      if (game.gameServer) {
+      if (newGame.gameServer) {
         this.gameRuntimeService
-          .replacePlayer(game.id, replaceeId, replacementSlot)
+          .replacePlayer(newGame.id, replaceeId, replacementSlot)
           .catch((error) => this.logger.warn(error));
       }
       return game;

--- a/src/plugins/discord/services/admin-notifications.service.spec.ts
+++ b/src/plugins/discord/services/admin-notifications.service.spec.ts
@@ -335,53 +335,18 @@ describe('AdminNotificationsService', () => {
         });
 
         events.gameChanges.next({
-          game: {
+          oldGame: {
             number: 1,
             state: GameState.started,
             id: 'FAKE_GAME_ID',
           } as Game,
-        });
-        events.gameChanges.next({
-          game: {
+          newGame: {
             number: 1,
             state: GameState.interrupted,
             id: 'FAKE_GAME_ID',
           } as Game,
           adminId: admin.id,
         });
-      }));
-  });
-
-  describe('when a game does not really change', () => {
-    let admin: Player;
-
-    beforeEach(async () => {
-      // @ts-expect-error
-      admin = await playersService._createOne();
-    });
-
-    it('should not send any message', async () =>
-      new Promise<void>((resolve) => {
-        events.gameChanges.next({
-          game: {
-            number: 2,
-            state: GameState.started,
-            id: 'FAKE_GAME_2_ID',
-          } as Game,
-        });
-        events.gameChanges.next({
-          game: {
-            number: 1,
-            state: GameState.interrupted,
-            id: 'FAKE_GAME_ID',
-          } as Game,
-          adminId: admin.id,
-        });
-
-        setTimeout(() => {
-          expect(sendSpy).not.toHaveBeenCalled();
-          resolve();
-        }, 1000);
       }));
   });
 

--- a/src/plugins/discord/services/admin-notifications.service.ts
+++ b/src/plugins/discord/services/admin-notifications.service.ts
@@ -9,12 +9,7 @@ import { PlayerSkillType } from '@/players/services/player-skill.service';
 import { PlayersService } from '@/players/services/players.service';
 import { iconUrlPath } from '@configs/discord';
 import { Injectable, OnModuleInit } from '@nestjs/common';
-import {
-  concatMap,
-  distinctUntilChanged,
-  filter,
-  groupBy,
-} from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 import {
   newPlayer,
   playerBanAdded,

--- a/src/plugins/discord/services/admin-notifications.service.ts
+++ b/src/plugins/discord/services/admin-notifications.service.ts
@@ -113,15 +113,12 @@ export class AdminNotificationsService implements OnModuleInit {
 
     this.events.gameChanges
       .pipe(
-        groupBy(({ game }) => game.id),
-        concatMap((group) =>
-          group.pipe(
-            distinctUntilChanged((x, y) => x.game.state === y.game.state),
-            filter(({ game }) => game.state === GameState.interrupted),
-          ),
-        ),
+        filter(({ oldGame, newGame }) => oldGame.state !== newGame.state),
+        filter(({ newGame }) => newGame.state === GameState.interrupted),
       )
-      .subscribe(({ game, adminId }) => this.onGameForceEnded(game, adminId));
+      .subscribe(({ newGame, adminId }) =>
+        this.onGameForceEnded(newGame, adminId),
+      );
 
     this.events.substituteRequested
       .pipe(filter(({ adminId }) => !!adminId))

--- a/src/voice-servers/mumble-bot.service.spec.ts
+++ b/src/voice-servers/mumble-bot.service.spec.ts
@@ -147,12 +147,11 @@ describe('MumbleBotService', () => {
       const oldGame = new Game();
       oldGame.number = 2;
       oldGame.state = GameState.started;
-      events.gameChanges.next({ game: oldGame });
 
       const newGame = new Game();
       newGame.number = 2;
       newGame.state = GameState.ended;
-      events.gameChanges.next({ game: newGame });
+      events.gameChanges.next({ oldGame, newGame });
     });
 
     it('should link channels', () => {


### PR DESCRIPTION
The gameChanges event should provide information about game both before and after it changes. Having only the updated instance does not let us react to changes properly.