### PR TITLE
fix(players): release all players on app startup

### DIFF
--- a/src/games/services/__mocks__/games.service.ts
+++ b/src/games/services/__mocks__/games.service.ts
@@ -46,6 +46,8 @@ export class GamesService {
   }
 
   getOrphanedGames = jest.fn();
+  getPlayerGameCount = jest.fn();
+  getPlayerPlayedClassCount = jest.fn();
 
   async _createOne(players?: Player[]) {
     let lastTeamId = 0;


### PR DESCRIPTION
Handle situation where the app is closed after a game ends, but before the participants are released.