### PR TITLE
feat(games): override logs.tf title

### DIFF
--- a/src/games/services/server-configurator.service.spec.ts
+++ b/src/games/services/server-configurator.service.spec.ts
@@ -19,6 +19,7 @@ import {
   delAllGamePlayers,
   disablePlayerWhitelist,
   tftrueWhitelistId,
+  logsTfTitle,
 } from '../utils/rcon-commands';
 import { Tf2Team } from '../models/tf2-team';
 import { Game, GameDocument, gameSchema } from '../models/game';
@@ -55,6 +56,7 @@ jest.mock('@/game-configs/services/game-configs.service');
 class EnvironmentStub {
   logRelayAddress = 'FAKE_RELAY_ADDRESS';
   logRelayPort = '1234';
+  websiteName = 'FAKE_WEBSITE_NAME';
 }
 
 class RconStub {
@@ -233,6 +235,9 @@ describe('ServerConfiguratorService', () => {
         ),
       );
       expect(rcon.send).toHaveBeenCalledWith(enablePlayerWhitelist());
+      expect(rcon.send).toHaveBeenCalledWith(
+        logsTfTitle('FAKE_WEBSITE_NAME #1'),
+      );
       expect(rcon.send).toHaveBeenCalledWith(tvPort());
       expect(rcon.send).toHaveBeenCalledWith(tvPassword());
     });

--- a/src/games/services/server-configurator.service.ts
+++ b/src/games/services/server-configurator.service.ts
@@ -16,6 +16,7 @@ import {
   tvPort,
   tvPassword,
   tftrueWhitelistId,
+  logsTfTitle,
 } from '../utils/rcon-commands';
 import { deburr } from 'lodash';
 import { extractConVarValue } from '../utils/extract-con-var-value';
@@ -116,6 +117,9 @@ export class ServerConfiguratorService {
       }
 
       await rcon.send(enablePlayerWhitelist());
+      await rcon.send(
+        logsTfTitle(`${this.environment.websiteName} #${game.number}`),
+      );
 
       const tvPortValue = extractConVarValue(await rcon.send(tvPort()));
       const tvPasswordValue = extractConVarValue(await rcon.send(tvPassword()));

--- a/src/games/utils/rcon-commands.ts
+++ b/src/games/utils/rcon-commands.ts
@@ -52,6 +52,10 @@ export function logAddressDel(logAddress: string) {
   return `logaddress_del ${logAddress}`;
 }
 
+export function logsTfTitle(logsTfTitle: string) {
+  return `logstf_title ${logsTfTitle}`;
+}
+
 export function setPassword(password: string) {
   return `sv_password ${password}`;
 }


### PR DESCRIPTION
Provided we use [F2's logs.tf plugin](https://github.com/F2/F2s-sourcemod-plugins), we are able to [override the name of the logs that are uploaded to logs.tf](https://github.com/F2/F2s-sourcemod-plugins/blob/1fc730995a7cc7b068a06c8b7bf3970f298f6e8b/logstf/logstf.sp#L168). Let's put it to good use.