### PR TITLE
fix(environment): get rid of variable name typo

### DIFF
--- a/src/environment-schema.ts
+++ b/src/environment-schema.ts
@@ -20,12 +20,7 @@ export const environmentSchema = object({
   MONGODB_URI: string().required().uri(),
   REDIS_URL: any().optional(),
   STEAM_API_KEY: string().required(),
-  KEY_STORE_PASSPHARE: string().optional(),
-  KEY_STORE_PASSPHRASE: when('KEY_STORE_PASSPHARE', {
-    is: exist(),
-    then: any().forbidden(),
-    otherwise: string().required(),
-  }),
+  KEY_STORE_PASSPHRASE: string().required(),
   SUPER_USER: string()
     .required()
     .pattern(/^\d{17}$/, { name: 'SteamID64' }),

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
@@ -38,14 +38,6 @@ export class Environment {
   }
 
   get keyStorePassphrase() {
-    // TODO v10: remove
-    if (this.configService.get<string>('KEY_STORE_PASSPHARE')) {
-      new Logger(Environment.name).warn(
-        'KEY_STORE_PASSPHARE is deprecated and will be removed in v10. Use KEY_STORE_PASSPHRASE instead',
-      );
-      return this.configService.get<string>('KEY_STORE_PASSPHARE');
-    }
-
     return this.configService.get<string>('KEY_STORE_PASSPHRASE');
   }
 


### PR DESCRIPTION
BREAKING CHANGE: KEY_STORE_PASSPHARE environment variable is renamed to KEY_STORE_PASSPHRASE.