### PR TITLE
fix(game-servers): workaround model providers

### DIFF
--- a/src/game-servers/game-servers.module.ts
+++ b/src/game-servers/game-servers.module.ts
@@ -2,15 +2,11 @@ import { forwardRef, Module } from '@nestjs/common';
 import { GameServersService } from './services/game-servers.service';
 import { GamesModule } from '@/games/games.module';
 import { GameServersProvidersModule } from './providers/game-servers-providers.module';
-import { StaticGameServerModule } from './providers/static-game-server/static-game-server.module';
 
 @Module({
   imports: [
     GameServersProvidersModule.configure(),
     forwardRef(() => GamesModule),
-
-    // FIXME This is a workaround for (probably) as NestJS bug, this shouldn't be needed here.
-    StaticGameServerModule,
   ],
   providers: [GameServersService],
   exports: [GameServersService, GameServersProvidersModule],

--- a/src/game-servers/providers/serveme-tf/serveme-tf.module.ts
+++ b/src/game-servers/providers/serveme-tf/serveme-tf.module.ts
@@ -7,22 +7,23 @@ import { servemeTfConfigurationModelProvider } from './serveme-tf-configuration-
 import { ConfigurationModule } from '@/configuration/configuration.module';
 import { ServemeTfConfigurationService } from './services/serveme-tf-configuration.service';
 import { ServemeTfController } from './controllers/serveme-tf.controller';
-import { MongooseModule } from '@nestjs/mongoose';
 import {
   ServemeTfGameServer,
   servemeTfGameServerSchema,
 } from './models/serveme-tf-game-server';
+import { workaroundModelProvider } from '@/utils/workaround-model-provider';
 
 @Module({
   imports: [
     HttpModule,
     forwardRef(() => GameServersModule),
     ConfigurationModule,
-    MongooseModule.forFeature([
-      { name: ServemeTfGameServer.name, schema: servemeTfGameServerSchema },
-    ]),
   ],
   providers: [
+    workaroundModelProvider({
+      name: ServemeTfGameServer.name,
+      schema: servemeTfGameServerSchema,
+    }),
     ServemeTfService,
     ServemeTfApiService,
     servemeTfConfigurationModelProvider,

--- a/src/game-servers/providers/static-game-server/static-game-server.module.ts
+++ b/src/game-servers/providers/static-game-server/static-game-server.module.ts
@@ -1,8 +1,8 @@
 import { GameServersModule } from '@/game-servers/game-servers.module';
 import { GamesModule } from '@/games/games.module';
 import { LogReceiverModule } from '@/log-receiver/log-receiver.module';
+import { workaroundModelProvider } from '@/utils/workaround-model-provider';
 import { forwardRef, Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 import { GameServerDiagnosticsController } from './controllers/game-server-diagnostics.controller';
 import { StaticGameServersController } from './controllers/static-game-servers.controller';
 import { LogForwarding } from './diagnostic-checks/log-forwarding';
@@ -20,21 +20,20 @@ import { StaticGameServersService } from './services/static-game-servers.service
 
 @Module({
   imports: [
-    forwardRef(() => GameServersModule),
-    MongooseModule.forFeature([
-      {
-        name: StaticGameServer.name,
-        schema: staticGameServerSchema,
-      },
-      {
-        name: GameServerDiagnosticRun.name,
-        schema: gameServerDiagnosticRunSchema,
-      },
-    ]),
-    LogReceiverModule,
     forwardRef(() => GamesModule),
+    forwardRef(() => GameServersModule),
+    LogReceiverModule,
   ],
   providers: [
+    workaroundModelProvider({
+      name: StaticGameServer.name,
+      schema: staticGameServerSchema,
+    }),
+    workaroundModelProvider({
+      name: GameServerDiagnosticRun.name,
+      schema: gameServerDiagnosticRunSchema,
+    }),
+
     StaticGameServersService,
     GameServerDiagnosticsService,
     RconConnection,

--- a/src/utils/workaround-model-provider.ts
+++ b/src/utils/workaround-model-provider.ts
@@ -1,0 +1,16 @@
+import { getConnectionToken, getModelToken } from '@nestjs/mongoose';
+import { Connection } from 'mongoose';
+
+interface WorkaroundModelProviderOptions {
+  name: string;
+  schema: any;
+}
+
+export const workaroundModelProvider = (
+  options: WorkaroundModelProviderOptions,
+) => ({
+  provide: getModelToken(options.name),
+  inject: [getConnectionToken()],
+  useFactory: (connection: Connection) =>
+    connection.model(options.name, options.schema),
+});


### PR DESCRIPTION
For some reason importing `MongooseModule.forFeature()` does not work (NestJS can't resolve injected models), so we need to fallback to a workaround - register model providers manually.