### PR TITLE
refactor(voice-servers): make a separate MumbleBot class

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     "relaypassword",
     "Serveme",
     "snakewater",
+    "subchannels",
     "tftrue",
     "typegoose",
     "unmark",

--- a/__mocks__/@tf2pickup-org/mumble-client.ts
+++ b/__mocks__/@tf2pickup-org/mumble-client.ts
@@ -57,15 +57,18 @@ class MockUser {
 
   setSelfMute = jest.fn().mockResolvedValue(this);
   setSelfDeaf = jest.fn().mockResolvedValue(this);
+
+  name = 'mock user';
 }
 
 class MockUserManager {}
 
 export class Client {
-  static _lastInstance;
+  static _lastInstance: Client;
   channels = new MockChannelManager();
   users = new MockUserManager();
   user = new MockUser();
+  welcomeText = 'FAKE_WELCOME_TEXT';
 
   constructor(public options: any) {
     Client._lastInstance = this;

--- a/src/games/services/__mocks__/games.service.ts
+++ b/src/games/services/__mocks__/games.service.ts
@@ -52,9 +52,6 @@ export class GamesService {
   getOrphanedGames = jest.fn();
   getPlayerGameCount = jest.fn();
   getPlayerPlayedClassCount = jest.fn();
-  getRunningGames = jest
-    .fn()
-    .mockImplementation(() => this._original.getRunningGames());
 
   async _createOne(players?: Player[]) {
     let lastTeamId = 0;

--- a/src/games/services/__mocks__/games.service.ts
+++ b/src/games/services/__mocks__/games.service.ts
@@ -52,6 +52,9 @@ export class GamesService {
   getOrphanedGames = jest.fn();
   getPlayerGameCount = jest.fn();
   getPlayerPlayedClassCount = jest.fn();
+  getRunningGames = jest
+    .fn()
+    .mockImplementation(() => this._original.getRunningGames());
 
   async _createOne(players?: Player[]) {
     let lastTeamId = 0;

--- a/src/voice-servers/errors/mumble-channel-does-not-exist.error.ts
+++ b/src/voice-servers/errors/mumble-channel-does-not-exist.error.ts
@@ -1,0 +1,5 @@
+export class MumbleChannelDoesNotExistError extends Error {
+  constructor(public readonly channelName: string) {
+    super(`mumble channel ${channelName} does not exist`);
+  }
+}

--- a/src/voice-servers/mumble-bot.service.spec.ts
+++ b/src/voice-servers/mumble-bot.service.spec.ts
@@ -19,7 +19,6 @@ jest.mock('@/environment/environment');
 jest.mock('@/configuration/services/configuration.service');
 jest.mock('@/certificates/services/certificates.service');
 jest.mock('@/games/services/games.service');
-jest.mock('@tf2pickup-org/mumble-client');
 jest.mock('@/game-coordinator/services/game-runtime.service');
 jest.mock('./mumble-bot');
 

--- a/src/voice-servers/mumble-bot.service.spec.ts
+++ b/src/voice-servers/mumble-bot.service.spec.ts
@@ -132,7 +132,7 @@ describe('MumbleBotService', () => {
         expect(mockMumbleBot.setupChannels).toHaveBeenCalledWith(game);
       });
 
-      it('should be called upon game creation', async () => {
+      it('should be called upon game creation', () => {
         const game = new Game();
         events.gameCreated.next({ game });
         expect(mockMumbleBot.setupChannels).toHaveBeenCalledWith(game);
@@ -146,7 +146,7 @@ describe('MumbleBotService', () => {
         expect(mockMumbleBot.linkChannels).toHaveBeenCalledWith(game);
       });
 
-      it('should be called when a game ends', async () => {
+      it('should be called when a game ends', () => {
         const oldGame = new Game();
         oldGame.state = GameState.started;
         const newGame = new Game();

--- a/src/voice-servers/mumble-bot.service.spec.ts
+++ b/src/voice-servers/mumble-bot.service.spec.ts
@@ -106,7 +106,7 @@ describe('MumbleBotService', () => {
       mockMumbleBot = mockInstances[mockInstances.length - 1];
     });
 
-    it('should create new mumble bot and connect', async () => {
+    it('should create new mumble bot and connect', () => {
       expect(
         MumbleBot as jest.MockedClass<typeof MumbleBot>,
       ).toHaveBeenCalledWith({

--- a/src/voice-servers/mumble-bot.service.spec.ts
+++ b/src/voice-servers/mumble-bot.service.spec.ts
@@ -14,6 +14,7 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Connection } from 'mongoose';
 import { MumbleBotService } from './mumble-bot.service';
 import { MumbleBot } from './mumble-bot';
+import { GameState } from '@/games/models/game-state';
 
 jest.mock('@/environment/environment');
 jest.mock('@/configuration/services/configuration.service');
@@ -130,6 +131,12 @@ describe('MumbleBotService', () => {
         await service.createChannels(game);
         expect(mockMumbleBot.setupChannels).toHaveBeenCalledWith(game);
       });
+
+      it('should be called upon game creation', async () => {
+        const game = new Game();
+        events.gameCreated.next({ game });
+        expect(mockMumbleBot.setupChannels).toHaveBeenCalledWith(game);
+      });
     });
 
     describe('#linkChannels()', () => {
@@ -137,6 +144,15 @@ describe('MumbleBotService', () => {
         const game = new Game();
         await service.linkChannels(game);
         expect(mockMumbleBot.linkChannels).toHaveBeenCalledWith(game);
+      });
+
+      it('should be called when a game ends', async () => {
+        const oldGame = new Game();
+        oldGame.state = GameState.started;
+        const newGame = new Game();
+        newGame.state = GameState.ended;
+        events.gameChanges.next({ oldGame, newGame });
+        expect(mockMumbleBot.linkChannels).toHaveBeenCalledWith(newGame);
       });
     });
 

--- a/src/voice-servers/mumble-bot.spec.ts
+++ b/src/voice-servers/mumble-bot.spec.ts
@@ -131,7 +131,7 @@ describe('MumbleBot', () => {
       });
 
       describe('when there are users in one of the subchannels', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           gameChannel.subChannels[0].users.push({});
         });
 

--- a/src/voice-servers/mumble-bot.spec.ts
+++ b/src/voice-servers/mumble-bot.spec.ts
@@ -1,0 +1,110 @@
+jest.mock('@tf2pickup-org/mumble-client');
+import { MumbleBot } from './mumble-bot';
+import { Client as MockClient } from '@mocks/@tf2pickup-org/mumble-client';
+import { Game } from '@/games/models/game';
+
+describe('MumbleBot', () => {
+  let mumbleBot: MumbleBot;
+  let client: MockClient;
+
+  beforeEach(() => {
+    mumbleBot = new MumbleBot({
+      host: 'FAKE_HOST',
+      port: 1234,
+      username: 'FAKE_USERNAME',
+      password: 'FAKE_PASSWORD',
+      clientName: 'FAKE_CLIENT_NAME',
+      certificate: {
+        id: 'FAKE_CERT_ID',
+        purpose: 'mumble',
+        clientKey: 'FAKE_KEY',
+        certificate: 'FAKE_CERTIFICATE',
+      },
+      targetChannelName: 'FAKE_CHANNEL_NAME',
+    });
+
+    client = MockClient._lastInstance;
+  });
+
+  it('should create', () => {
+    expect(mumbleBot).toBeTruthy();
+  });
+
+  describe('#connect()', () => {
+    beforeEach(async () => {
+      await mumbleBot.connect();
+    });
+
+    it('should call client.connect()', () => {
+      expect(client.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should self-deafen', () => {
+      expect(client.user.setSelfDeaf).toHaveBeenCalledWith(true);
+    });
+
+    describe('#disconnect()', () => {
+      beforeEach(() => {
+        mumbleBot.disconnect();
+      });
+
+      it('should call client.disconnect()', () => {
+        expect(client.disconnect).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('#setupChannels()', () => {
+    let game: Game;
+
+    beforeEach(() => {
+      game = new Game();
+      game.id = 'FAKE_GAME_ID';
+      game.number = 1;
+    });
+
+    it('should create subchannels', async () => {
+      await mumbleBot.setupChannels(game);
+      expect(client.user.channel.subChannels[0].name).toBe('1');
+      expect(client.user.channel.subChannels[0].subChannels[0].name).toBe(
+        'BLU',
+      );
+      expect(client.user.channel.subChannels[0].subChannels[1].name).toBe(
+        'RED',
+      );
+    });
+
+    describe('if moved to another channel', () => {
+      beforeEach(async () => {
+        await client.user.moveToChannel(128);
+      });
+
+      it('should move back to the right channel', async () => {
+        await mumbleBot.setupChannels(game);
+        expect(client.user.channel.id).toBe(0);
+        expect(client.user.channel.subChannels[0].name).toBe('1');
+      });
+    });
+  });
+
+  describe('#linkChannels()', () => {
+    let game: Game;
+
+    beforeEach(async () => {
+      game = new Game();
+      game.id = 'FAKE_GAME_ID';
+      game.number = 2;
+
+      const ch = await client.user.channel.createSubChannel('2');
+      await ch.createSubChannel('BLU');
+      await ch.createSubChannel('RED');
+    });
+
+    it('should link channels', async () => {
+      await mumbleBot.linkChannels(game);
+      const red = client.user.channel.subChannels[0].subChannels[1];
+      expect(red.link).toHaveBeenCalled();
+      expect(red.links.length).toBe(1);
+    });
+  });
+});

--- a/src/voice-servers/mumble-bot.ts
+++ b/src/voice-servers/mumble-bot.ts
@@ -1,0 +1,139 @@
+import { Certificate } from '@/certificates/models/certificate';
+import { Game } from '@/games/models/game';
+import { Tf2Team } from '@/games/models/tf2-team';
+import { Logger } from '@nestjs/common';
+import { Client } from '@tf2pickup-org/mumble-client';
+import { toUpper } from 'lodash';
+
+interface MumbleBotOptions {
+  host: string;
+  port: number;
+  username: string;
+  password?: string;
+  tokens?: string[];
+  clientName?: string;
+  certificate: Certificate;
+  targetChannelName: string;
+}
+
+// subchannels for each game
+const subChannelNames = [toUpper(Tf2Team.blu), toUpper(Tf2Team.red)];
+
+export class MumbleBot {
+  private readonly client: Client;
+  private readonly logger = new Logger(MumbleBot.name);
+
+  constructor(public readonly options: MumbleBotOptions) {
+    this.client = new Client({
+      host: this.options.host,
+      port: this.options.port,
+      username: this.options.username,
+      password: this.options.password,
+      clientName: this.options.clientName,
+      key: this.options.certificate.clientKey,
+      cert: this.options.certificate.certificate,
+      rejectUnauthorized: false,
+    });
+  }
+
+  async connect() {
+    await this.client.connect();
+    this.logger.log(`logged in as ${this.client.user.name}`);
+    this.logger.debug(this.client.welcomeText);
+    await this.client.user.setSelfDeaf(true);
+    await this.moveToTargetChannel();
+
+    const permissions = await this.client.user.channel.getPermissions();
+    if (!permissions.canCreateChannel) {
+      this.logger.warn(
+        `Bot ${this.client.user.name} does not have permissions to create new channels`,
+      );
+    }
+  }
+
+  disconnect() {
+    this.client.disconnect();
+  }
+
+  async setupChannels(game: Game) {
+    await this.moveToTargetChannel();
+    const channelName = `${game.number}`;
+    const channel = await this.client.user.channel.createSubChannel(
+      channelName,
+    );
+    await Promise.all(
+      subChannelNames.map(
+        async (subChannelName) =>
+          await channel.createSubChannel(subChannelName),
+      ),
+    );
+    this.logger.verbose(`channels for game #${game.number} created`);
+  }
+
+  async linkChannels(game: Game) {
+    const channelName = `${game.number}`;
+    const gameChannel = this.client.user.channel.subChannels.find(
+      (channel) => channel.name === channelName,
+    );
+    if (!gameChannel) {
+      throw new Error('channel does not exist');
+    }
+
+    const [red, blu] = [
+      gameChannel.subChannels.find(
+        (channel) => channel.name.toUpperCase() === 'RED',
+      ),
+      gameChannel.subChannels.find(
+        (channel) => channel.name.toUpperCase() === 'BLU',
+      ),
+    ];
+    if (red && blu) {
+      await red.link(blu);
+      this.logger.log(`channels for game #${game.number} linked`);
+    } else {
+      throw new Error('BLU or RED subchannel does not exist');
+    }
+  }
+
+  async removeObsoleteChannels(runningGames: Game[]) {
+    await this.moveToTargetChannel();
+
+    /**
+     * For each channel lookup the assigned game and see whether it has ended.
+     * For ended games, make sure there are no players in the corresponding voice channel and then remove it.
+     */
+    await Promise.all(
+      this.client.user.channel.subChannels.map(async (channel) => {
+        try {
+          const gameNumber = parseInt(channel.name, 10);
+          if (isNaN(gameNumber)) {
+            return;
+          }
+
+          if (runningGames.find((game) => game.number === gameNumber)) {
+            return;
+          }
+
+          const userCount =
+            channel.subChannels
+              .map((c) => c.users.length)
+              .reduce((prev, curr) => prev + curr, 0) + channel.users.length;
+
+          if (userCount > 0) {
+            return;
+          }
+
+          await channel.remove();
+          this.logger.log(`channel ${channel.name} removed`);
+        } catch (error) {
+          this.logger.error(`cannot remove channel ${channel.name}: ${error}`);
+        }
+      }),
+    );
+  }
+
+  private async moveToTargetChannel() {
+    const channel = this.client.channels.byName(this.options.targetChannelName);
+    await this.client.user.moveToChannel(channel.id);
+  }
+}


### PR DESCRIPTION
Creating a separate `MumbleBot` class for managing the mumble bot (duh) makes it easier to test & maintain code.