### PR TITLE
fix(queue): synchronous join queue

### DIFF
--- a/src/queue/errors/player-denied.error.ts
+++ b/src/queue/errors/player-denied.error.ts
@@ -1,7 +1,17 @@
 import { Player } from '@/players/models/player';
 
+export enum DenyReason {
+  playerHasNotAcceptedRules = 'player has not accepted rules',
+  noSkillAssigned = 'player has no skill assigned',
+  playerIsBanned = 'player is banned',
+  playerIsInvolvedInGame = 'player is involved in a game',
+}
+
 export class PlayerDeniedError extends Error {
-  constructor(public readonly player: Player, public readonly reason: string) {
+  constructor(
+    public readonly player: Player,
+    public readonly reason: DenyReason,
+  ) {
     super(`player ${player.name} denied from joining the queue (${reason})`);
   }
 }

--- a/src/queue/errors/player-has-not-accepted-rules.error.ts
+++ b/src/queue/errors/player-has-not-accepted-rules.error.ts
@@ -1,5 +1,0 @@
-export class PlayerHasNotAcceptedRulesError extends Error {
-  constructor(public playerId: string) {
-    super(`player (${playerId}) has not accepted rules`);
-  }
-}

--- a/src/queue/errors/player-involved-in-game.error.ts
+++ b/src/queue/errors/player-involved-in-game.error.ts
@@ -1,5 +1,0 @@
-export class PlayerInvolvedInGameError extends Error {
-  constructor(public playerId: string) {
-    super(`player (${playerId}) is involved in a game`);
-  }
-}

--- a/src/queue/errors/player-is-banned.error.ts
+++ b/src/queue/errors/player-is-banned.error.ts
@@ -1,5 +1,0 @@
-export class PlayerIsBannedError extends Error {
-  constructor(public playerId: string) {
-    super(`player (${playerId}) is banned`);
-  }
-}

--- a/src/queue/gateways/queue.gateway.spec.ts
+++ b/src/queue/gateways/queue.gateway.spec.ts
@@ -101,8 +101,8 @@ describe('QueueGateway', () => {
   });
 
   describe('#joinQueue()', () => {
-    it('should join the queue', async () => {
-      await gateway.joinQueue({ user: { id: 'FAKE_PLAYER_ID' } } as Socket, {
+    it('should join the queue', () => {
+      gateway.joinQueue({ user: { id: 'FAKE_PLAYER_ID' } } as Socket, {
         slotId: 5,
       });
       expect(queueService.join).toHaveBeenCalledWith(5, 'FAKE_PLAYER_ID');
@@ -128,7 +128,7 @@ describe('QueueGateway', () => {
   });
 
   describe('#markFriend()', () => {
-    it('should mark friend', async () => {
+    it('should mark friend', () => {
       gateway.markFriend({ user: { id: 'FAKE_PLAYER_ID' } } as Socket, {
         friendPlayerId: 'FAKE_FRIEND_ID',
       });

--- a/src/queue/gateways/queue.gateway.spec.ts
+++ b/src/queue/gateways/queue.gateway.spec.ts
@@ -9,6 +9,8 @@ import { Socket } from 'socket.io';
 import { Tf2ClassName } from '@/shared/models/tf2-class-name';
 import { QueueSlotWrapper } from '../controllers/queue-slot-wrapper';
 import { QueueState } from '../queue-state';
+import { ConfigurationService } from '@/configuration/services/configuration.service';
+import { PlayerBansService } from '@/players/services/player-bans.service';
 
 jest.mock('../services/queue.service');
 jest.mock('socket.io');
@@ -16,6 +18,8 @@ jest.mock('../services/map-vote.service');
 jest.mock('../services/queue-announcements.service');
 jest.mock('../services/friends.service');
 jest.mock('../controllers/queue-slot-wrapper');
+jest.mock('@/configuration/services/configuration.service');
+jest.mock('@/players/services/player-bans.service');
 
 const mockSubstituteRequests = [
   {
@@ -44,6 +48,8 @@ describe('QueueGateway', () => {
         MapVoteService,
         QueueAnnouncementsService,
         FriendsService,
+        ConfigurationService,
+        PlayerBansService,
       ],
     }).compile();
 
@@ -56,7 +62,7 @@ describe('QueueGateway', () => {
   });
 
   beforeEach(() => {
-    queueService.join.mockResolvedValue([
+    queueService.join.mockReturnValue([
       {
         id: 5,
         playerId: 'FAKE_PLAYER_ID',

--- a/src/queue/guards/can-join-queue.guard.spec.ts
+++ b/src/queue/guards/can-join-queue.guard.spec.ts
@@ -1,0 +1,7 @@
+import { CanJoinQueueGuard } from './can-join-queue.guard';
+
+describe('CanJoinQueueGuard', () => {
+  it('should be defined', () => {
+    expect(new CanJoinQueueGuard()).toBeDefined();
+  });
+});

--- a/src/queue/guards/can-join-queue.guard.spec.ts
+++ b/src/queue/guards/can-join-queue.guard.spec.ts
@@ -1,7 +1,151 @@
+import { ConfigurationEntryKey } from '@/configuration/models/configuration-entry-key';
+import { ConfigurationService } from '@/configuration/services/configuration.service';
+import { Player } from '@/players/models/player';
+import { PlayerBan } from '@/players/models/player-ban';
+import { PlayerBansService } from '@/players/services/player-bans.service';
+import { ExecutionContext } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { Types } from 'mongoose';
+import { PlayerDeniedError } from '../errors/player-denied.error';
 import { CanJoinQueueGuard } from './can-join-queue.guard';
 
+jest.mock('@/configuration/services/configuration.service');
+jest.mock('@/players/services/player-bans.service');
+
 describe('CanJoinQueueGuard', () => {
+  let guard: CanJoinQueueGuard;
+  let configurationService: jest.Mocked<ConfigurationService>;
+  let playerBansService: jest.Mocked<PlayerBansService>;
+
+  beforeEach(() => {
+    configurationService = new ConfigurationService(
+      null,
+      null,
+    ) as jest.Mocked<ConfigurationService>;
+    playerBansService = new PlayerBansService(
+      null,
+      null,
+      null,
+      null,
+    ) as jest.Mocked<PlayerBansService>;
+    guard = new CanJoinQueueGuard(configurationService, playerBansService);
+  });
+
+  beforeEach(() => {
+    configurationService.getDenyPlayersWithNoSkillAssigned.mockResolvedValue({
+      key: ConfigurationEntryKey.denyPlayersWithNoSkillAssigned,
+      value: false,
+    });
+    playerBansService.getPlayerActiveBans.mockResolvedValue([]);
+  });
+
   it('should be defined', () => {
-    expect(new CanJoinQueueGuard()).toBeDefined();
+    expect(guard).toBeDefined();
+  });
+
+  describe('#canActivate()', () => {
+    let client: { user?: Player };
+    let context: jest.Mocked<ExecutionContext>;
+
+    beforeEach(() => {
+      client = {};
+      context = {
+        switchToWs: jest.fn().mockImplementation(() => ({
+          getClient: jest.fn().mockReturnValue(client),
+          getData: jest.fn(),
+        })),
+      } as unknown as jest.Mocked<ExecutionContext>;
+    });
+
+    describe('when not logged in', () => {
+      it('should deny', async () => {
+        await expect(guard.canActivate(context)).rejects.toThrow(WsException);
+      });
+    });
+
+    describe('when the player has not accepted rules', () => {
+      let player: Player;
+
+      beforeEach(() => {
+        player = new Player();
+        player.hasAcceptedRules = false;
+        client.user = player;
+      });
+
+      it('should deny', async () => {
+        await expect(guard.canActivate(context)).rejects.toThrow(
+          PlayerDeniedError,
+        );
+      });
+    });
+
+    describe('when the player has no skill assigned', () => {
+      let player: Player;
+
+      beforeEach(() => {
+        player = new Player();
+        player.hasAcceptedRules = true;
+        client.user = player;
+      });
+
+      describe('and he should be denied', () => {
+        beforeEach(() => {
+          configurationService.getDenyPlayersWithNoSkillAssigned.mockResolvedValue(
+            {
+              key: ConfigurationEntryKey.denyPlayersWithNoSkillAssigned,
+              value: true,
+            },
+          );
+        });
+
+        it('should deny', async () => {
+          await expect(guard.canActivate(context)).rejects.toThrow(
+            PlayerDeniedError,
+          );
+        });
+      });
+
+      describe("but it's ok", () => {
+        it('should allow', async () => {
+          expect(await guard.canActivate(context)).toBe(true);
+        });
+      });
+    });
+
+    describe('when the player is banned', () => {
+      let player: Player;
+
+      beforeEach(() => {
+        player = new Player();
+        player.hasAcceptedRules = true;
+        client.user = player;
+
+        const ban = new PlayerBan();
+        playerBansService.getPlayerActiveBans.mockResolvedValue([ban]);
+      });
+
+      it('should deny', async () => {
+        await expect(guard.canActivate(context)).rejects.toThrow(
+          PlayerDeniedError,
+        );
+      });
+    });
+
+    describe('when the player is involved in a game', () => {
+      let player: Player;
+
+      beforeEach(() => {
+        player = new Player();
+        player.hasAcceptedRules = true;
+        player.activeGame = new Types.ObjectId();
+        client.user = player;
+      });
+
+      it('should deny', async () => {
+        await expect(guard.canActivate(context)).rejects.toThrow(
+          PlayerDeniedError,
+        );
+      });
+    });
   });
 });

--- a/src/queue/guards/can-join-queue.guard.ts
+++ b/src/queue/guards/can-join-queue.guard.ts
@@ -13,7 +13,7 @@ export class CanJoinQueueGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const player = (context.switchToWs().getClient() as Socket).user;
+    const player = context.switchToWs().getClient<Socket>().user;
     if (!player) {
       throw new WsException('not logged in');
     }

--- a/src/queue/guards/can-join-queue.guard.ts
+++ b/src/queue/guards/can-join-queue.guard.ts
@@ -1,0 +1,46 @@
+import { ConfigurationService } from '@/configuration/services/configuration.service';
+import { PlayerBansService } from '@/players/services/player-bans.service';
+import { PlayersService } from '@/players/services/players.service';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { Socket } from 'socket.io';
+import { PlayerDeniedError } from '../errors/player-denied.error';
+
+@Injectable()
+export class CanJoinQueueGuard implements CanActivate {
+  constructor(
+    private readonly playersService: PlayersService,
+    private readonly configurationService: ConfigurationService,
+    private readonly playerBansService: PlayerBansService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const player = (context.switchToWs().getClient() as Socket).user;
+    if (!player) {
+      throw new WsException('not logged in');
+    }
+
+    if (!player.hasAcceptedRules) {
+      throw new PlayerDeniedError(player, 'player has not accepted rules');
+    }
+
+    if (
+      !player.skill &&
+      (await this.configurationService.getDenyPlayersWithNoSkillAssigned())
+        .value
+    ) {
+      throw new PlayerDeniedError(player, 'no skill assigned');
+    }
+
+    const bans = await this.playerBansService.getPlayerActiveBans(player.id);
+    if (bans.length > 0) {
+      throw new PlayerDeniedError(player, 'player is banned');
+    }
+
+    if (player.activeGame) {
+      throw new PlayerDeniedError(player, 'player is involved in a game');
+    }
+
+    return true;
+  }
+}

--- a/src/queue/services/queue.service.spec.ts
+++ b/src/queue/services/queue.service.spec.ts
@@ -216,7 +216,7 @@ describe('QueueService', () => {
       });
 
       describe('when the player tries to join an already occupied slot', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           service.join(0, 'FAKE_PLAYER_2_ID');
         });
 

--- a/src/queue/services/queue.service.ts
+++ b/src/queue/services/queue.service.ts
@@ -133,9 +133,9 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
       targetSlot.ready = true;
     }
 
-    // this.logger.debug(
-    //   `player ${player.name} joined the queue (slotId=${targetSlot.id}, gameClass=${targetSlot.gameClass})`,
-    // );
+    this.logger.debug(
+      `player ${playerId} joined the queue (slotId=${targetSlot.id}, gameClass=${targetSlot.gameClass})`,
+    );
 
     // is player joining instead of only changing slots?
     if (oldSlots.length === 0) {

--- a/src/queue/services/queue.service.ts
+++ b/src/queue/services/queue.service.ts
@@ -2,14 +2,11 @@ import {
   Injectable,
   Logger,
   Inject,
-  forwardRef,
   OnModuleInit,
   OnModuleDestroy,
   CACHE_MANAGER,
 } from '@nestjs/common';
 import { QueueSlot } from '@/queue/queue-slot';
-import { PlayersService } from '@/players/services/players.service';
-import { PlayerBansService } from '@/players/services/player-bans.service';
 import { QueueState } from '../queue-state';
 import { readyUpTimeout, readyStateTimeout } from '@configs/queue';
 import { Events } from '@/events/events';
@@ -20,7 +17,6 @@ import { PlayerNotInTheQueueError } from '../errors/player-not-in-the-queue.erro
 import { WrongQueueStateError } from '../errors/wrong-queue-state.error';
 import { CannotJoinAtThisQueueStateError } from '../errors/cannot-join-at-this-queue-state.error';
 import { Cache } from 'cache-manager';
-import { ConfigurationService } from '@/configuration/services/configuration.service';
 import { QueueConfig } from '@/queue-config/interfaces/queue-config';
 
 interface Queue {
@@ -50,14 +46,10 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
   }
 
   constructor(
-    @Inject(forwardRef(() => PlayersService))
-    private playersService: PlayersService,
     @Inject('QUEUE_CONFIG')
     private readonly queueConfig: QueueConfig,
-    private playerBansService: PlayerBansService,
     private events: Events,
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
-    private readonly configurationService: ConfigurationService,
   ) {}
 
   async onModuleInit() {

--- a/src/shared/filters/all-exceptions.filter.spec.ts
+++ b/src/shared/filters/all-exceptions.filter.spec.ts
@@ -1,4 +1,8 @@
-import { PlayerInvolvedInGameError } from '@/queue/errors/player-involved-in-game.error';
+import { Player } from '@/players/models/player';
+import {
+  DenyReason,
+  PlayerDeniedError,
+} from '@/queue/errors/player-denied.error';
 import { AllExceptionsFilter } from './all-exceptions.filter';
 
 describe('AllExceptionsFilter', () => {
@@ -17,8 +21,14 @@ describe('AllExceptionsFilter', () => {
       }),
     };
 
+    const player = new Player();
+    player.name = 'FAKE_PLAYER_NAME';
+
     const filter = new AllExceptionsFilter();
-    filter.catch(new PlayerInvolvedInGameError('FAKE_PLAYER_ID'), host as any);
+    filter.catch(
+      new PlayerDeniedError(player, DenyReason.playerIsBanned),
+      host as any,
+    );
     expect(socket.emit).toHaveBeenCalledWith('exception', {
       message: expect.any(String),
     });


### PR DESCRIPTION
Make the `QueueService.join()` method synchronous, meaning we can drop using mutexes, therefore potentially optimizing the application a little bit. All the checks are being performed in the guard before calling the actual `join()` method.

TODO: e2e tests