### PR TITLE
fix(*): relax REDIS_URL schema

### DIFF
--- a/src/environment-schema.ts
+++ b/src/environment-schema.ts
@@ -17,7 +17,7 @@ export const environmentSchema = object({
   CLIENT_URL: string().required(),
   BOT_NAME: string().required(),
   MONGODB_URI: string().required().uri(),
-  REDIS_URL: string().required().uri(),
+  REDIS_URL: string().required(),
   STEAM_API_KEY: string().required(),
   LOGS_TF_API_KEY: string().required(),
   KEY_STORE_PASSPHRASE: string().required(),


### PR DESCRIPTION
The REDIS_URL can be a file path and fail the `uri()` validation, so let's get rid of it.