### PR TITLE
feat(games): accept steamId64 for /games?player endpoint

### DIFF
--- a/src/games/controllers/games.controller.spec.ts
+++ b/src/games/controllers/games.controller.spec.ts
@@ -11,6 +11,7 @@ import { GameServerAssignerService } from '../services/game-server-assigner.serv
 
 jest.mock('../services/player-substitution.service');
 jest.mock('../services/game-server-assigner.service');
+jest.mock('@/players/pipes/player-by-id.pipe');
 
 class GamesServiceStub {
   games: Game[] = [
@@ -94,15 +95,12 @@ describe('Games Controller', () => {
       });
     });
 
-    describe('when playerId is specified', () => {
+    describe('when the player is specified', () => {
       it('should return player games', async () => {
         const spy = jest.spyOn(gamesService, 'getPlayerGames');
-        const ret = await controller.getGames(
-          10,
-          0,
-          { 'events.0.at': -1 },
-          'FAKE_PLAYER_ID',
-        );
+        const ret = await controller.getGames(10, 0, { 'events.0.at': -1 }, {
+          id: 'FAKE_PLAYER_ID',
+        } as Player);
         expect(spy).toHaveBeenCalledWith(
           'FAKE_PLAYER_ID',
           { 'events.0.at': -1 },

--- a/src/games/controllers/games.controller.ts
+++ b/src/games/controllers/games.controller.ts
@@ -32,6 +32,7 @@ import { GameServerOptionIdentifier } from '@/game-servers/interfaces/game-serve
 import { GameServerAssignerService } from '../services/game-server-assigner.service';
 import { ParseSortParamsPipe } from '../pipes/parse-sort-params.pipe';
 import { GameByIdOrNumberPipe } from '../pipes/game-by-id-or-number.pipe';
+import { PlayerByIdPipe } from '@/players/pipes/player-by-id.pipe';
 
 @Controller('games')
 export class GamesController {
@@ -48,20 +49,21 @@ export class GamesController {
     @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
     @Query('sort', new DefaultValuePipe('-launched_at'), ParseSortParamsPipe)
     sort: Record<string, 1 | -1>,
-    @Query('playerId') playerId?: string,
+    @Query('player', PlayerByIdPipe)
+    player?: Player,
   ): Promise<PaginatedGameListDto> {
     let results: Game[];
     let itemCount: number;
 
-    if (playerId === undefined) {
+    if (!player) {
       [results, itemCount] = await Promise.all([
         this.gamesService.getGames(sort, limit, offset),
         this.gamesService.getGameCount(),
       ]);
     } else {
       [results, itemCount] = await Promise.all([
-        this.gamesService.getPlayerGames(playerId, sort, limit, offset),
-        this.gamesService.getPlayerGameCount(playerId),
+        this.gamesService.getPlayerGames(player.id, sort, limit, offset),
+        this.gamesService.getPlayerGameCount(player.id),
       ]);
     }
 

--- a/src/players/pipes/player-by-id.pipe.spec.ts
+++ b/src/players/pipes/player-by-id.pipe.spec.ts
@@ -7,6 +7,8 @@ import { Connection, Types } from 'mongoose';
 import { Player, PlayerDocument, playerSchema } from '../models/player';
 import { PlayersService } from '../services/players.service';
 import { PlayerByIdPipe } from './player-by-id.pipe';
+// eslint-disable-next-line jest/no-mocks-import
+import { PlayersService as MockedPlayersService } from '../services/__mocks__/players.service';
 
 jest.mock('../services/players.service');
 
@@ -14,7 +16,7 @@ describe('PlayerByIdPipe', () => {
   let pipe: PlayerByIdPipe;
   let mongod: MongoMemoryServer;
   let connection: Connection;
-  let playersService: PlayersService;
+  let playersService: MockedPlayersService;
 
   beforeAll(async () => (mongod = await MongoMemoryServer.create()));
   afterAll(async () => mongod.stop());
@@ -34,12 +36,11 @@ describe('PlayerByIdPipe', () => {
     }).compile();
 
     playersService = module.get(PlayersService);
-    pipe = new PlayerByIdPipe(playersService);
+    pipe = new PlayerByIdPipe(playersService as unknown as PlayersService);
     connection = module.get(getConnectionToken());
   });
 
   afterEach(async () => {
-    // @ts-expect-error
     await playersService._reset();
     await connection.close();
   });
@@ -52,13 +53,12 @@ describe('PlayerByIdPipe', () => {
     let player: Player;
 
     beforeEach(async () => {
-      // @ts-expect-error
       player = await playersService._createOne();
     });
 
     it('should fetch the player by id', async () => {
-      const p = await pipe.transform(player.id);
-      expect(p.id).toEqual(player.id);
+      const ret = await pipe.transform(player.id);
+      expect(ret?.id).toEqual(player.id);
     });
   });
 
@@ -66,15 +66,14 @@ describe('PlayerByIdPipe', () => {
     let player: PlayerDocument;
 
     beforeEach(async () => {
-      // @ts-expect-error
       player = await playersService._createOne();
       player.steamId = '76561198074409147';
       await player.save();
     });
 
     it('should fetch the player by steam id', async () => {
-      const p = await pipe.transform(player.steamId);
-      expect(p.id).toEqual(player.id);
+      const ret = await pipe.transform(player.steamId);
+      expect(ret?.id).toEqual(player.id);
     });
   });
 

--- a/src/players/pipes/player-by-id.pipe.spec.ts
+++ b/src/players/pipes/player-by-id.pipe.spec.ts
@@ -19,7 +19,7 @@ describe('PlayerByIdPipe', () => {
   let playersService: MockedPlayersService;
 
   beforeAll(async () => (mongod = await MongoMemoryServer.create()));
-  afterAll(async () => mongod.stop());
+  afterAll(async () => await mongod.stop());
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({

--- a/src/players/pipes/player-by-id.pipe.ts
+++ b/src/players/pipes/player-by-id.pipe.ts
@@ -26,6 +26,8 @@ export class PlayerByIdPipe
 
         case 'steam-id':
           return await this.playersService.findBySteamId(playerId.steamId64);
+
+        // no default
       }
     } catch (error) {
       if (error instanceof Error.DocumentNotFoundError) {

--- a/src/players/pipes/player-by-id.pipe.ts
+++ b/src/players/pipes/player-by-id.pipe.ts
@@ -1,16 +1,23 @@
 import { ObjectIdOrSteamIdPipe } from '@/shared/pipes/object-id-or-steam-id.pipe';
 import { Injectable, NotFoundException, PipeTransform } from '@nestjs/common';
+import { isUndefined } from 'lodash';
 import { Error } from 'mongoose';
 import { Player } from '../models/player';
 import { PlayersService } from '../services/players.service';
 
 @Injectable()
-export class PlayerByIdPipe implements PipeTransform<string, Promise<Player>> {
+export class PlayerByIdPipe
+  implements PipeTransform<string, Promise<Player | undefined>>
+{
   private objectIdOrSteamIdValidationPipe = new ObjectIdOrSteamIdPipe();
 
   constructor(private playersService: PlayersService) {}
 
-  async transform(value: string): Promise<Player> {
+  async transform(value: string): Promise<Player | undefined> {
+    if (isUndefined(value)) {
+      return undefined;
+    }
+
     try {
       const playerId = this.objectIdOrSteamIdValidationPipe.transform(value);
       switch (playerId.type) {


### PR DESCRIPTION
BREAKING CHANGE: The `playerId` param is renamed to `player`.